### PR TITLE
Drop support for Node 12

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
     steps:
     - name: Checkout dapp
       uses: actions/checkout@v2


### PR DESCRIPTION
https://github.com/Agoric/agoric-sdk/pull/3140 dropped support for Node 12 in the SDK, and the root `package.json` was updated accordingly. This causes CI tests running on that version to fail here because of the dependency, so this PR similarly removes the CI job.