### PR TITLE
Testnet compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,13 @@ ui/.cache/
 ui/dist/
 /Dockerfile
 /results
+
+_agstate/agoric-wallet
+_agstate/keys
+
+_agstate/agoric-servers/solo
+_agstate/agoric-servers/dev
+_agstate/agoric-servers/testnet-*
+_agstate/agoric-servers/chain
+_agstate/agoric-servers/ve*
+_agstate/agoric-servers/local-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,7 @@ ENV IS_DOCKER=true
 ENV SDK_SRC=/src
 ENV OUTPUT_DIR=/out
 ENV SDK_REVISION=
+ENV SDK_BUILD=0
 
 WORKDIR /app
 COPY --chown=$USER_UID:$USER_GID . .
@@ -158,4 +159,4 @@ RUN mkdir -p $SDK_SRC $OUTPUT_DIR && chown $USER_UID:$USER_GID $SDK_SRC $OUTPUT_
 
 USER $USER_UID:$USER_GID
 
-ENTRYPOINT ["/tini", "--", "/app/start.sh"]
+ENTRYPOINT ["/tini", "--", "/app/start.sh", "--no-reset"]

--- a/README-extended.md
+++ b/README-extended.md
@@ -158,11 +158,3 @@ To disable all generators:
 ```sh
 curl -X PUT --data '{}' http://127.0.0.1:3352/config
 ```
-
-### Loadgen types
-
-The load generators defined so far:
-
-- `faucet`: initialize by creating a `dapp-fungible-faucet` -style mint, then each cycle requests an invitation and completes it, adding 1000 Tokens to Bob's Purse. Takes 4 round-trips to complete.
-- `amm`: initialize by selling some (currently 33%) of the initial RUN to get BLD, then record the balances. Each cycle sells 1% of the recorded BLD to get RUN, then sells 1% of the recorded RUN to get BLD. Because of fees, the total available will drop slowly over time.
-- `vault`: initialize by recording our BLD balance and the BLD/RUN price. Each cycle deposits 1% of the recorded BLD balance and borrows half its value in RUN, then pays back the loan and recovers the BLD (less fees).

--- a/README-extended.md
+++ b/README-extended.md
@@ -1,4 +1,4 @@
-# Load Generator
+# Load Generator (Extended)
 
 ## Runner
 

--- a/README-extended.md
+++ b/README-extended.md
@@ -38,7 +38,7 @@ Currently the following options are available:
 - `--stage.duration`: the time in minutes to use as default duration for each loadgen stage (non chain-only, see below). Defaults to 360 minutes (6 hours).
 - `--stage.n.*`: Override config for a given stage 0 <= n < `--stages`
 - `--stage.n.loadgen.*`: the object to use as loadgen config for the given stage. If specified and `chain-only` is missing Created from multiple arguments and passed as-is to the loadgen tool.
-- `--stage.n.
+- `--stage.n.`
 - `--stage.n.chain-only`: boolean flag specifying if the stage should only run the chain node and not start a client or loadgen. Defaults to `true` for first and last stage. Defaults to `false` for other stages, or if `--stage.n.loadgen.*` is specified.
 - `--stage.n.save-storage`: boolean indicating if the storage of the chain node should be saved at the end of the stage. Defaults to `true` for non stage-only stages (where the loadgen runs), as well as for stage 0 (to capture local bootstrap).
 - `--stage.n.duration`: the time in minutes for the stage duration. Defaults to the shared duration above for non chain-only stages, or 0 (immediate stop after start) otherwise. Use a negative value to run until interrupted.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ or directly using the `agoric` cli
 agoric deploy loadgen/loop.js
 ```
 
-See the [delpoy CLI reference](https://agoric.com/documentation/guides/agoric-cli/commands.html#agoric-deploy) for options like configuring the host/port of the client.
+See the [deploy CLI reference](https://agoric.com/documentation/guides/agoric-cli/commands.html#agoric-deploy) for options like configuring the host/port of the client.
 
 ## Loadgen types
 

--- a/README.md
+++ b/README.md
@@ -164,5 +164,5 @@ curl -X PUT --data '{}' http://127.0.0.1:3352/config
 The load generators defined so far:
 
 - `faucet`: initialize by creating a `dapp-fungible-faucet` -style mint, then each cycle requests an invitation and completes it, adding 1000 Tokens to Bob's Purse. Takes 4 round-trips to complete.
-- `amm`: initialize by selling half of the initial RUN to get BLD, then record the balances. Each cycle sells 1% of the recorded BLD to get RUN, then sells 1% of the recorded RUN to get BLD. Because of fees, the total available will drop slowly over time.
+- `amm`: initialize by selling some (currently 33%) of the initial RUN to get BLD, then record the balances. Each cycle sells 1% of the recorded BLD to get RUN, then sells 1% of the recorded RUN to get BLD. Because of fees, the total available will drop slowly over time.
 - `vault`: initialize by recording our BLD balance and the BLD/RUN price. Each cycle deposits 1% of the recorded BLD balance and borrows half its value in RUN, then pays back the loan and recovers the BLD (less fees).

--- a/README.md
+++ b/README.md
@@ -164,5 +164,5 @@ curl -X PUT --data '{}' http://127.0.0.1:3352/config
 The load generators defined so far:
 
 - `faucet`: initialize by creating a `dapp-fungible-faucet` -style mint, then each cycle requests an invitation and completes it, adding 1000 Tokens to Bob's Purse. Takes 4 round-trips to complete.
-- `amm`: initialize by selling half our BLD to get RUN, then record the balances. Each cycle sells 1% of the recorded BLD to get RUN, then sells 1% of the recorded RUN to get BLD. Because of fees, the total available will drop slowly over time.
+- `amm`: initialize by selling half of the initial RUN to get BLD, then record the balances. Each cycle sells 1% of the recorded BLD to get RUN, then sells 1% of the recorded RUN to get BLD. Because of fees, the total available will drop slowly over time.
 - `vault`: initialize by recording our BLD balance and the BLD/RUN price. Each cycle deposits 1% of the recorded BLD balance and borrows half its value in RUN, then pays back the loan and recovers the BLD (less fees).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Load Generator
+
+The loadgen is implemented as a dapp deploy script which runs forever and listens for config updates. It can perform 3 different type of load generating tasks at any given interval (cycle): `faucet`, `amm`, `vault`. Each task is deployed to a vat on the solo client. Additionally the `faucet` task installs a faucet app on the chain. When the loadgen server starts a task's cycle, it invokes the task's agent running on the solo client, which performs its load generation on the chain.
+
+The loadgen accepts config updates from a local http port.
+
+For alternative usages of the loadgen, see the [Extended Readme](./README-extended.md).
+
+## Setup
+
+Since the loadgen is a dapp, it requires a local `agoric-sdk` to execute, and a running solo client provisioned and connected to a chain.
+
+### Prerequisite
+
+Make sure you have the `agoric-sdk` with the correct revision built, with the `agoric` cli available in your PATH. Follow the steps in the guide to [Install the SDK](https://github.com/Agoric/agoric-sdk/wiki/Validator-Guide-for-Incentivized-Testnet#install-agoric-sdk).
+
+### Running client
+
+To interact with the chain, a client must be running. With a local agoric-sdk available, the easiest to run a client for the testnet chain is directly using the following command:
+
+```sh
+agoric start testnet
+```
+
+The above command stores the client's state in the current directory's `_agstate/agoric-servers/testnet-8000`. If for any reason you need to reset your client, you can delete that directory.
+
+More information can be found in the [agoric CLI reference](https://agoric.com/documentation/guides/agoric-cli/commands.html#agoric-start).
+
+Alternatively, you can run the [client as a docker image](https://github.com/Agoric/agoric-sdk/wiki/Setting-up-an-Agoric-Dapp-Client-with-docker-compose).
+
+#### Optional: Make client use a private RPC node
+
+To avoid having the solo client, and by extension the loadgen, be impacted by load on public RPC nodes, it's preferable to initially configure the client to connect to a private RPC chain node. When running the solo client directly, the easiest is to start the client specifying a modified network-config.
+
+```sh
+wget https://testnet.agoric.net/network-config
+vi network-config # add/replace rpcAddrs with the address of the local chain node
+agoric start testnet 8000 $(pwd)/network-config
+```
+
+### Start the loadgen
+
+After the client is started (`Deployed Wallet!` shown in the output), the loadgen can be started as well.
+
+```sh
+yarn loadgen
+```
+
+or directly using the `agoric` cli
+
+```sh
+agoric deploy loadgen/loop.js
+```
+
+See the [delpoy CLI reference](https://agoric.com/documentation/guides/agoric-cli/commands.html#agoric-deploy) for options like configuring the host/port of the client.
+
+## Loadgen types
+
+The load generators defined so far:
+
+- `faucet`: initialize by creating a `dapp-fungible-faucet` -style mint on the chain, then each cycle requests an invitation and completes it, adding 1000 Tokens to Bob's Purse. Takes 4 round-trips to complete.
+- `amm`: initialize by selling some (currently 33%) of the initial RUN to get BLD, then record the balances. Each cycle sells 1% of the recorded BLD to get RUN, then sells 1% of the recorded RUN to get BLD. Because of fees, the total available will drop slowly over time.
+- `vault`: initialize by recording our BLD balance and the BLD/RUN price. Each cycle deposits 1% of the recorded BLD balance and borrows half its value in RUN, then pays back the loan and recovers the BLD (less fees).

--- a/loadgen/agent-trade-amm.js
+++ b/loadgen/agent-trade-amm.js
@@ -30,18 +30,10 @@ export default async function startAgent([key, home]) {
     let bal;
     if (which === 'RUN') {
       bal = await E(runPurse).getCurrentAmount();
-      if (AmountMath.isEmpty(bal)) {
-        // some chain setups currently fail to make the purses visible with
-        // the right denominations
-        throw Error(`no RUN, trade-amm cannot proceed`);
-      }
       return bal;
     }
     if (which === 'BLD') {
       bal = await E(bldPurse).getCurrentAmount();
-      if (AmountMath.isEmpty(bal)) {
-        throw Error(`no BLD, trade-amm cannot proceed`);
-      }
       return bal;
     }
     throw Error(`unknown type ${which}`);
@@ -99,10 +91,13 @@ export default async function startAgent([key, home]) {
     console.error(`trade-amm setup: initial RUN=${disp(run)} BLD=${disp(bld)}`);
     // eslint-disable-next-line no-constant-condition
     if (1) {
-      // setup: buy RUN with 50% of our BLD
-      console.error(`trade-amm: buying initial RUN with 50% of our BLD`);
-      const halfAmount = AmountMath.make(bldBrand, bld.value / BigInt(2));
-      await buyRunWithBld(halfAmount);
+      // setup: buy BLD with 50% of our RUN
+      console.error(`trade-amm: buying initial BLD with 50% of our RUN`);
+      if (AmountMath.isEmpty(run)) {
+        throw Error(`no RUN, trade-amm cannot proceed`);
+      }
+      const halfAmount = AmountMath.make(runBrand, run.value / BigInt(2));
+      await buyBldWithRun(halfAmount);
       ({ run, bld } = await getBalances());
     }
     // we sell 1% of the holdings each time

--- a/loadgen/agent-trade-amm.js
+++ b/loadgen/agent-trade-amm.js
@@ -9,7 +9,7 @@ import { allValues } from './allValues';
 // The default export function is called with some args.
 
 export default async function startAgent([key, home]) {
-  const { zoe, scratch, agoricNames, wallet } = home;
+  const { zoe, scratch, agoricNames, wallet, faucet } = home;
 
   console.error(`trade-amm: building tools`);
   // const runIssuer = await E(agoricNames).lookup('issuer', issuerPetnames.RUN);
@@ -91,13 +91,20 @@ export default async function startAgent([key, home]) {
     console.error(`trade-amm setup: initial RUN=${disp(run)} BLD=${disp(bld)}`);
     // eslint-disable-next-line no-constant-condition
     if (1) {
-      // setup: buy BLD with 50% of our RUN
-      console.error(`trade-amm: buying initial BLD with 50% of our RUN`);
+      // TODO: change to the appropriate amounts
+      // setup: buy BLD with 33% of our initial RUN
+      console.error(`trade-amm: buying initial BLD with 33% of our RUN`);
       if (AmountMath.isEmpty(run)) {
         throw Error(`no RUN, trade-amm cannot proceed`);
       }
-      const halfAmount = AmountMath.make(runBrand, run.value / BigInt(2));
-      await buyBldWithRun(halfAmount);
+      const thirdRunAmount = AmountMath.make(runBrand, run.value / 3n);
+      await buyBldWithRun(thirdRunAmount);
+
+      // setup: transfer other 33% (remaining half) of our RUN to the feePurse
+      const feePurse = E(faucet).getFeePurse();
+      const feePayment = await E(runPurse).withdraw(thirdRunAmount);
+      await E(feePurse).deposit(feePayment);
+
       ({ run, bld } = await getBalances());
     }
     // we sell 1% of the holdings each time

--- a/loadgen/loop.js
+++ b/loadgen/loop.js
@@ -19,8 +19,8 @@ let currentConfig = {
 
 const tasks = {
   faucet: [prepareFaucet],
-  // we must start the AMM task before Vault, because it sells BLD, and both
-  // measure the balance
+  // we must start the AMM task before Vault: AMM exchanges some RUN for BLD,
+  // and Vault measures the balances
   amm: [prepareAMMTrade],
   vault: [prepareVaultCycle],
 };

--- a/loadgen/loop.js
+++ b/loadgen/loop.js
@@ -3,14 +3,14 @@
 
 import { performance } from 'perf_hooks';
 import http from 'http';
-import { prepareFaucet } from './task-tap-faucet';
+// import { prepareFaucet } from './task-tap-faucet';
 import { prepareAMMTrade } from './task-trade-amm';
 import { prepareVaultCycle } from './task-create-vault';
 
 // we want mostly AMM tasks, and only occasional vault tasks
 
 let currentConfig = {
-  faucet: null, // or { interval=60, limit=1, wait=0 }
+  // faucet: null, // or { interval=60, limit=1, wait=0 }
   amm: null,
   vault: null,
   // amm: { interval: 120},
@@ -18,7 +18,7 @@ let currentConfig = {
 };
 
 const tasks = {
-  faucet: [prepareFaucet],
+  // faucet: [prepareFaucet],
   // we must start the AMM task before Vault: AMM exchanges some RUN for BLD,
   // and Vault measures the balances
   amm: [prepareAMMTrade],

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -145,7 +145,12 @@ const coerceBooleanOption = (
   defaultValue,
   assertBool = true,
 ) => {
-  switch (maybeBoolValue) {
+  const value =
+    assertBool && Array.isArray(maybeBoolValue)
+      ? maybeBoolValue.slice(-1)[0]
+      : maybeBoolValue;
+
+  switch (value) {
     case 1:
     case true:
     case 'true':

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -883,11 +883,17 @@ const main = async (progName, rawArgs, powers) => {
       });
 
       const withMonitor = coerceBooleanOption(argv.monitor, true);
+      const globalChainOnly = coerceBooleanOption(argv.chainOnly, undefined);
       {
         const { releaseInterrupt } = makeInterrupterKit();
 
         const reset = coerceBooleanOption(argv.reset, true);
-        const setupConfig = { reset, withMonitor, testnetOrigin };
+        const setupConfig = {
+          reset,
+          chainOnly: globalChainOnly,
+          withMonitor,
+          testnetOrigin,
+        };
         logPerfEvent('setup-tasks-start', setupConfig);
         await aggregateTryFinally(
           // Do not short-circuit on interrupt, let the spawned setup process terminate
@@ -924,7 +930,7 @@ const main = async (progName, rawArgs, powers) => {
 
         const withLoadgen = coerceBooleanOption(
           stageConfig.loadgen,
-          undefined,
+          globalChainOnly ? false : undefined,
           false,
         );
 
@@ -936,14 +942,16 @@ const main = async (progName, rawArgs, powers) => {
         // By default the first stage will only initialize the chain from genesis
         // and the last stage will only capture the chain restart time
         // loadgen and chainOnly options overide default
-        const chainOnly = coerceBooleanOption(
-          stageConfig.chainOnly,
-          withLoadgen != null
-            ? !withLoadgen // use boolean loadgen option value as default chainOnly
-            : loadgenConfig === sharedLoadgenConfig && // user provided stage loadgen config implies chain
-                withMonitor && // If monitor is disabled, chainOnly has no meaning
-                (currentStage === 0 || currentStage === stages - 1),
-        );
+        const chainOnly =
+          globalChainOnly ||
+          coerceBooleanOption(
+            stageConfig.chainOnly,
+            withLoadgen != null
+              ? !withLoadgen // use boolean loadgen option value as default chainOnly
+              : loadgenConfig === sharedLoadgenConfig && // user provided stage loadgen config implies chain
+                  withMonitor && // If monitor is disabled, chainOnly has no meaning
+                  (currentStage === 0 || currentStage === stages - 1),
+          );
 
         const saveStorage = coerceBooleanOption(
           stageConfig.saveStorage,

--- a/start.sh
+++ b/start.sh
@@ -22,6 +22,7 @@ then
     then
         git -C "${SDK_SRC}" reset --hard ${SDK_REVISION}
     fi
+    SDK_BUILD=1
 fi
 
 SDK_FULL_REVISION=$(git -C "${SDK_SRC}" rev-parse HEAD)
@@ -43,9 +44,11 @@ mkdir -p "${OUTPUT_DIR}"
 export PATH=$AGORIC_BIN_DIR:$PATH
 
 cd "$SDK_SRC"
-yarn install
-yarn build
-make -C packages/cosmic-swingset
+if [ "x$SDK_BUILD" != "x0" ]; then
+    yarn install
+    yarn build
+    make -C packages/cosmic-swingset
+fi
 
 rm -f "${AGORIC_BIN_DIR}/agoric"
 yarn link-cli "${AGORIC_BIN_DIR}/agoric"


### PR DESCRIPTION
This PR updates the AMM task to provision the fee purse (subsuming #16), and updates the Readme with clear instructions for how to setup a loadgen running against testnet. Existing details on how the automated runner works have been moved to an extended readme file (2 separate commits for easier diffing).

The initial RUN split is currently set to use 1/3 for fees and 1/3 to buy BLD. We can update as necessary.