### PR TITLE
Testnet runner fixes

### DIFF
--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -256,6 +256,7 @@ const main = async (progName, rawArgs, powers) => {
   console.log(`Outputting to ${resolvePath(outputDir)}`);
   await fs.mkdir(outputDir, { recursive: true });
 
+  /** @type {typeof makeLocalChainTasks | typeof makeTestnetTasks} */
   let makeTasks;
   /** @type {string} */
   let testnetOrigin;
@@ -966,7 +967,9 @@ const main = async (progName, rawArgs, powers) => {
         const duration =
           (stageConfig.duration != null
             ? Number(stageConfig.duration)
-            : (!chainOnly && sharedStageDurationMinutes) || 0) *
+            : (!(chainOnly && makeTasks === makeLocalChainTasks) &&
+                sharedStageDurationMinutes) ||
+              0) *
           60 *
           1000;
 

--- a/start.sh
+++ b/start.sh
@@ -52,6 +52,7 @@ fi
 
 rm -f "${AGORIC_BIN_DIR}/agoric"
 yarn link-cli "${AGORIC_BIN_DIR}/agoric"
+ln -s "$SDK_SRC/packages/cosmic-swingset/bin/ag-chain-cosmos" "${AGORIC_BIN_DIR}/ag-chain-cosmos"
 
 cd "$LOADGEN_DIR"
 agoric install


### PR DESCRIPTION
Small fixes to automate running chain monitor through the runner under more scenarios:
- Shared docker volume for source (to avoid recompiling the SDK every start)
- restarting chain only monitor with shared stage duration