### PR TITLE
Loadgen security rules and better disconnect handling

### DIFF
--- a/loadgen/database.rules.json
+++ b/loadgen/database.rules.json
@@ -1,6 +1,105 @@
 {
   "rules": {
-    ".read": "now < 1631689200000",  // 2021-9-15
-    ".write": "now < 1631689200000",  // 2021-9-15
+    ".read": true, // 2021-9-15
+    "users": {
+      "$userId": {
+        "activeLoadgens": {
+          "$loadgenId": {
+            // Do not allow old loadgens
+            ".validate": false
+          }
+        },
+        "activeLoadgenClients": {
+          ".write": "$userId === auth.uid",
+          "$clientId": {
+            ".validate": "newData.val() === true && root.child('loadgen').child('clients').child($clientId).exists()"
+          }
+        }
+        // Allow other fields on user
+      }
+    },
+    "loadgen": {
+      "clients": {
+        ".indexOn": ["connected"],
+        "$clientId": {
+          ".write": "newData.child('userId').val() === auth.uid",
+          "connected": {
+            ".validate": "newData.isBoolean()"
+          },
+          "connectedAt": {
+            ".validate": "newData.val() == now"
+          },
+          "disconnectedAt": {
+            ".validate": "newData.val() == now"
+          },
+          "userId": {
+            ".validate": "(!data.exists() || newData.val() === data.val()) && newData.val() === auth.uid"
+          },
+          "walletAddress": {
+            ".validate": "(!data.exists() || newData.val() === data.val()) && newData.isString()"
+          },
+          "$other": {
+            ".validate": false
+          }
+        }
+      },
+      "configs": {
+        "$configId": {
+          ".write": "root.child('loadgen/clients').child(newData.child('clientId').val()).child('userId').val() === auth.uid",
+          "clientId": {
+            ".validate": "!data.exists()"
+          },
+          "updatedAt": {
+            ".validate": "newData.isNumber()"
+          },
+          "data": {
+            ".validate": true
+          },
+          "$other": {
+            ".validate": false
+          }
+        }
+      },
+      "cycles": {
+        ".indexOn": ["success"],
+        "$cycleId": {
+          ".write": "root.child('loadgen/clients').child(newData.child('clientId').val()).child('userId').val() === auth.uid",
+          "clientId": {
+            ".validate": "!data.exists()"
+          },
+          "startedAt": {
+            ".validate": "newData.isNumber()"
+          },
+          "endedAt": {
+            ".validate": "newData.isNumber()"
+          },
+          "disconnectedAt": {
+            ".validate": "newData.val() == now"
+          },
+          "type": {
+            ".validate": "!data.exists() && newData.isString()"
+          },
+          "seq": {
+            ".validate": "!data.exists() && newData.isNumber()"
+          },
+          "success": {
+            ".validate": "newData.isBoolean()"
+          },
+          "$other": {
+            ".validate": false
+          }
+        }
+      },
+      "requestedConfigs": {
+        ".write": "root.child('users').child(auth.uid).child('admin').val() === true",
+        "$clientId": {
+          ".write": "!newData.exists() && root.child('loadgen/clients').child($clientId).child('userId').val() === auth.uid",
+          ".validate": "root.child('loadgen/clients').child($clientId).exists()"
+        }
+      }
+    },
+    "$other": {
+      ".validate": false
+    }
   }
 }

--- a/loadgen/database.rules.json
+++ b/loadgen/database.rules.json
@@ -20,7 +20,7 @@
     },
     "loadgen": {
       "clients": {
-        ".indexOn": ["connected"],
+        ".indexOn": ["connected", "userId"],
         "$clientId": {
           ".write": "newData.child('userId').val() === auth.uid",
           "connected": {
@@ -44,6 +44,7 @@
         }
       },
       "configs": {
+        ".indexOn": ["clientId"],
         "$configId": {
           ".write": "root.child('loadgen/clients').child(newData.child('clientId').val()).child('userId').val() === auth.uid",
           "clientId": {
@@ -61,7 +62,7 @@
         }
       },
       "cycles": {
-        ".indexOn": ["success"],
+        ".indexOn": ["success", "clientId"],
         "$cycleId": {
           ".write": "root.child('loadgen/clients').child(newData.child('clientId').val()).child('userId').val() === auth.uid",
           "clientId": {

--- a/loadgen/firebase/admin.js
+++ b/loadgen/firebase/admin.js
@@ -81,10 +81,8 @@ export const adminConnectionHandlerFactory = (app) => {
 
     if (
       Number.isNaN(effectiveCycleStarts) ||
-      Math.abs(
-        ((effectiveCycleStarts - targetCycleStarts) * 2) /
-          (effectiveCycleStarts + targetCycleStarts),
-      ) >
+      Math.abs((effectiveCycleStarts - targetCycleStarts) * 2) /
+        (effectiveCycleStarts + targetCycleStarts) >
         10 / 100
     ) {
       console.log(
@@ -98,7 +96,8 @@ export const adminConnectionHandlerFactory = (app) => {
 
     // console.log({ requestedClients, candidates });
     if (
-      ((requestedClients - candidates) * 2) / (requestedClients + candidates) >
+      Math.abs((requestedClients - candidates) * 2) /
+        (requestedClients + candidates) >
       10 / 100
     ) {
       console.log(
@@ -144,7 +143,7 @@ export const adminConnectionHandlerFactory = (app) => {
 
     user = newUser;
 
-    if (user || true) {
+    if (user) {
       goOnline(db);
       console.log('connecting');
     }

--- a/loadgen/firebase/client.js
+++ b/loadgen/firebase/client.js
@@ -45,8 +45,10 @@ export const makeClientConnectionHandlerFactory = (walletAddress) => (app) => {
     if (user === newUser) return;
 
     if (user) {
-      connectedUnsubscribe();
-      connectedUnsubscribe = null;
+      if (connectedUnsubscribe) {
+        connectedUnsubscribe();
+        connectedUnsubscribe = null;
+      }
       goOffline(db);
       userActiveClient = null;
       if (configHandler) {

--- a/loadgen/firebase/database.rules.json
+++ b/loadgen/firebase/database.rules.json
@@ -12,7 +12,7 @@
         "activeLoadgenClients": {
           ".write": "$userId === auth.uid",
           "$clientId": {
-            ".validate": "newData.val() === true && root.child('loadgen').child('clients').child($clientId).exists()"
+            ".validate": "(newData.val() === true || newData.val() == now) && root.child('loadgen').child('clients').child($clientId).exists()"
           }
         }
         // Allow other fields on user

--- a/loadgen/firebase/firebase.json
+++ b/loadgen/firebase/firebase.json
@@ -1,0 +1,5 @@
+{
+  "database": {
+    "rules": "database.rules.json"
+  }
+}


### PR DESCRIPTION
- Sets up security rules to prevent unexpected changes to the orchestration data. The security rules are currently manually deployed through the console.
- Improve the setup of onDisconnect and add a keep alive mechanism to hopefully make loadgen clients data more reliable (I saw some "cycles" zombie entries, but strangely no client marked connected when they're not)
- Fix a couple issues in the orchestrator script