### PR TITLE
Make runner compatible with wide range of SDK revisions

### DIFF
--- a/runner/jsconfig.json
+++ b/runner/jsconfig.json
@@ -2,6 +2,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
+    "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
     "checkJs": true,

--- a/runner/lib/helpers/module.js
+++ b/runner/lib/helpers/module.js
@@ -1,0 +1,24 @@
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
+
+/**
+ *
+ * @param {string} specified
+ * @param {string | URL} parent
+ */
+export const resolve = async (specified, parent) => {
+  if (!parent) {
+    throw new TypeError('Invalid parent');
+  }
+  try {
+    if (import.meta.resolve) {
+      return await import.meta.resolve(specified, parent);
+    }
+  } catch (err) {
+    // Fall-through
+  }
+
+  const require = createRequire(parent);
+
+  return pathToFileURL(require.resolve(specified)).href;
+};

--- a/runner/lib/helpers/module.js
+++ b/runner/lib/helpers/module.js
@@ -15,6 +15,9 @@ export const resolve = async (specified, parent) => {
       return await import.meta.resolve(specified, parent);
     }
   } catch (err) {
+    if (/MODULE_NOT_FOUND/.test(/** @type {any} */ (err).code)) {
+      throw err;
+    }
     // Fall-through
   }
 

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -16,7 +16,12 @@ import yargsParser from 'yargs-parser';
 import chalk from 'chalk';
 import { makePromiseKit } from './sdk/promise-kit.js';
 
-import { sleep, aggregateTryFinally, sequential } from './helpers/async.js';
+import {
+  sleep,
+  aggregateTryFinally,
+  sequential,
+  tryTimeout,
+} from './helpers/async.js';
 import { childProcessDone } from './helpers/child-process.js';
 import { fsStreamReady, makeFsHelper } from './helpers/fs.js';
 import { makeProcfsHelper } from './helpers/procsfs.js';
@@ -439,10 +444,12 @@ const main = async (progName, rawArgs, powers) => {
           logPerfEvent('chain-ready');
           stageConsole.log('Chain ready');
 
-          await Promise.race([
-            slogMonitorDone,
-            orInterrupt(firstBlockDoneKit.promise),
-          ]);
+          await tryTimeout(60 * 1000, () =>
+            Promise.race([
+              slogMonitorDone,
+              orInterrupt(firstBlockDoneKit.promise),
+            ]),
+          );
           await orInterrupt(firstEmptyBlockKit.promise);
 
           await nextStep(done);

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -154,8 +154,19 @@ const getSDKBinaries = async () => {
     const { resolve } = await import('./helpers/module.js');
     // Older SDKs were only at lib
     const cliHelpersUrl = await resolve(libHelpers, import.meta.url);
+    // Prefer CJS as some versions have both and must use .cjs for RESM
+    let agSolo = new URL('../../solo/src/entrypoint.cjs', cliHelpersUrl)
+      .pathname;
+    if (
+      !(await resolve(agSolo, import.meta.url).then(
+        () => true,
+        () => false,
+      ))
+    ) {
+      agSolo = agSolo.replace(/\.cjs$/, '.js');
+    }
     return {
-      agSolo: new URL('../../solo/src/entrypoint.js', cliHelpersUrl).pathname,
+      agSolo,
       cosmosChain: new URL(
         '../../cosmic-swingset/bin/ag-chain-cosmos',
         cliHelpersUrl,

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -52,10 +52,17 @@ const clientArgvMatcher = wrapArgvMatcherIgnoreEnvShebang(
  * @param {import("fs/promises")} powers.fs Node.js promisified fs object
  * @param {import("../helpers/fs.js").MakeFIFO} powers.makeFIFO Make a FIFO file readable stream
  * @param {import("../helpers/procsfs.js").GetProcessInfo} powers.getProcessInfo
+ * @param {import("./types.js").SDKBinaries} powers.sdkBinaries
  * @returns {import("./types.js").OrchestratorTasks}
  *
  */
-export const makeTasks = ({ spawn: cpSpawn, fs, makeFIFO, getProcessInfo }) => {
+export const makeTasks = ({
+  spawn: cpSpawn,
+  fs,
+  makeFIFO,
+  getProcessInfo,
+  sdkBinaries,
+}) => {
   const spawn = makeSpawnWithPipedStream({
     spawn: cpSpawn,
     end: false,
@@ -242,7 +249,7 @@ export const makeTasks = ({ spawn: cpSpawn, fs, makeFIFO, getProcessInfo }) => {
     chainEnv.SLOGFILE = slogFifo.path;
     // chainEnv.DEBUG = 'agoric';
 
-    const launcherCp = printerSpawn('ag-chain-cosmos', ['start'], {
+    const launcherCp = printerSpawn(sdkBinaries.cosmosChain, ['start'], {
       stdio: ['ignore', 'pipe', stdio[2]],
       env: chainEnv,
       detached: true,

--- a/runner/lib/tasks/types.d.ts
+++ b/runner/lib/tasks/types.d.ts
@@ -7,6 +7,12 @@ export interface EnvInfo {
   readonly agChainCosmosVersion?: unknown;
 }
 
+export interface SDKBinaries {
+  readonly agSolo: string;
+  readonly cosmosChain: string;
+  readonly cosmosHelper: string;
+}
+
 export type TaskResult = {
   readonly stop: () => void;
   readonly done: Promise<void>;

--- a/runner/lib/tasks/types.d.ts
+++ b/runner/lib/tasks/types.d.ts
@@ -49,6 +49,7 @@ export type TaskEvent = TaskEventStatus | TaskEventStart | TaskEventFinish;
 
 export type RunLoadgenInfo = {
   readonly taskEvents: AsyncIterable<TaskEvent>;
+  updateConfig(newConfig: unknown): Promise<void>;
 };
 
 export type RunChainResult = TaskResult & RunChainInfo;

--- a/runner/package.json
+++ b/runner/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@endo/eslint-config": "^0.3.9",
+    "@types/node": "^16.9.1",
     "@types/readline-transform": "^1.0.0",
     "@types/yargs-parser": "^20.2.1",
     "ava": "^3.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,6 +2019,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.6.1.tgz#aee62c7b966f55fc66c7b6dfa1d58db2a616da61"
   integrity sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==
 
+"@types/node@^16.9.1":
+  version "16.11.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.10.tgz#2e3ad0a680d96367103d3e670d41c2fed3da61ae"
+  integrity sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
When I started regenerating the corpus of stats, I realized that the runner and loadgen did not run correctly against both older and newer SDK revisions (I was working against a somewhat outdated version).

In particular:
- Newer SDKs do not provide sufficient RUN/BLD to pay for Zoe fees and let the loadgen complete multiple cycles
- When killing the chain while under load (middle of a mailbox delivery), the validator node would stall on restart (https://github.com/Agoric/agoric-sdk/issues/4115)
- The stats of shorter stages would be impacted by increasing setup time that was performed during stage 1, causing these stats to be unreliable

The first issue is fixed by provisioning and starting the local-solo manually, which required hooking into the cli to figure out the right path to use across revisions.

The second issue is addressed by winding down the loadgen before shutting everything down. The issue has since been fixed in the agoric-sdk (https://github.com/Agoric/agoric-sdk/pull/4116), but the workaround is left for older revisions, and is made configurable if we want to test for regressions.

For the last issue, the default config moves the wallet and loadgen deployments to stage 0, which is now truly a full setup stage.

As always, best reviewed commit-by-commit.

Stacks on top of the stats work (#36).