### PR TITLE
Better runner compatibility with testnet

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-node_modules
+**/node_modules
+**/.git
 defaults.js
 installationConstants.js
 _agstate/yarn-links/
@@ -7,6 +8,14 @@ ui/.cache/
 ui/dist/
 /Dockerfile
 /results
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+firebase-debug.log*
+firebase-debug.*.log*
+.firebase/
 
 _agstate/agoric-wallet
 _agstate/keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/typescript-node/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/v0.209.3/containers/typescript-node/.devcontainer/Dockerfile
 
-# [Choice] Node.js version: 16, 14, 12
-ARG VARIANT="14-buster"
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT} as base
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT=16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT} as dev-env
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
@@ -16,69 +16,69 @@ FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT} as base
 # RUN su node -c "npm install -g <your-package-list -here>"
 
 ##############################
-# From https://github.com/docker-library/golang/blob/master/1.16/buster/Dockerfile
+# From https://github.com/docker-library/golang/blob/master/1.17/bullseye/Dockerfile
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.16.5
+ENV GOLANG_VERSION 1.17.4
 
 RUN set -eux; \
-	\
-	dpkgArch="$(dpkg --print-architecture)"; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
-	case "${dpkgArch##*-}" in \
+	case "$arch" in \
 		'amd64') \
-			url='https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz'; \
-			sha256='b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061'; \
+			url='https://dl.google.com/go/go1.17.4.linux-amd64.tar.gz'; \
+			sha256='adab2483f644e2f8a10ae93122f0018cef525ca48d0b8764dae87cb5f4fd4206'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://dl.google.com/go/go1.16.5.linux-armv6l.tar.gz'; \
-			sha256='93cacacfbe87e3106b5bf5821de106f0f0a43c8bd1029826d44445c15df795a5'; \
+			url='https://dl.google.com/go/go1.17.4.linux-armv6l.tar.gz'; \
+			sha256='f34d25f818007345b716b316908115ba462f3f0dbd4343073020b544b4ae2320'; \
 			;; \
 		'arm64') \
-			url='https://dl.google.com/go/go1.16.5.linux-arm64.tar.gz'; \
-			sha256='d5446b46ef6f36fdffa852f73dfbbe78c1ddf010b99fa4964944b9ae8b4d6799'; \
+			url='https://dl.google.com/go/go1.17.4.linux-arm64.tar.gz'; \
+			sha256='617a46bd083e59877bb5680998571b3ddd4f6dcdaf9f8bf65ad4edc8f3eafb13'; \
 			;; \
 		'i386') \
-			url='https://dl.google.com/go/go1.16.5.linux-386.tar.gz'; \
-			sha256='a37c6b71d0b673fe8dfeb2a8b3de78824f05d680ad32b7ac6b58c573fa6695de'; \
+			url='https://dl.google.com/go/go1.17.4.linux-386.tar.gz'; \
+			sha256='276bda8e8efa59482b0be87394566e02ff7a860b65e8b6ccc90c026dbcab1f74'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://dl.google.com/go/go1.16.5.linux-ppc64le.tar.gz'; \
-			sha256='fad2da6c86ede8448d2d0e66e1776e2f0ae9169714eade29b9ffbbdede7fc6cc'; \
+			url='https://dl.google.com/go/go1.17.4.linux-ppc64le.tar.gz'; \
+			sha256='d185567480d9e335d4d9274804ef9fa796b01e53c7290a744871d0c0fac2f248'; \
 			;; \
 		's390x') \
-			url='https://dl.google.com/go/go1.16.5.linux-s390x.tar.gz'; \
-			sha256='21085f6a3568fae639edf383cce78bcb00d8f415e5e3d7feb04b6124e8e9efc1'; \
+			url='https://dl.google.com/go/go1.17.4.linux-s390x.tar.gz'; \
+			sha256='63e4e2065aa3139b4d9a203fa7e39a810f67e9f4753492726d485c17c37cd817'; \
 			;; \
-		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	build=; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.16.5.src.tar.gz'; \
-		sha256='7bfa7e5908c7cc9e75da5ddf3066d7cbcf3fd9fa51945851325eebc17f50ba80'; \
+		url='https://dl.google.com/go/go1.17.4.src.tar.gz'; \
+		sha256='4bef3699381ef09e075628504187416565d710660fec65b057edf1ceb187fc4b'; \
 		echo >&2; \
-		echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \
+		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
 		echo >&2; \
 	fi; \
 	\
-	wget -O go.tgz.asc "$url.asc" --progress=dot:giga; \
+	wget -O go.tgz.asc "$url.asc"; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
-	echo "$sha256 *go.tgz" | sha256sum --strict --check -; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
 	\
 # https://github.com/golang/go/issues/14739#issuecomment-324767697
-	export GNUPGHOME="$(mktemp -d)"; \
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
 # https://www.google.com/linuxrepositories/
-#	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
-  curl 'https://dl.google.com/linux/linux_signing_key.pub' | gpg --batch --import; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
 	gpg --batch --verify go.tgz.asc go.tgz; \
 	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" go.tgz.asc; \
@@ -127,13 +127,16 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 #WORKDIR $GOPATH
 
 ##############################
-# From https://github.com/microsoft/vscode-dev-containers/blob/v0.163.1/containers/go/.devcontainer/base.Dockerfile
+# From https://github.com/microsoft/vscode-dev-containers/blob/v0.209.3/containers/go/.devcontainer/base.Dockerfile
+
+COPY library-scripts/go-debian.sh /tmp/library-scripts/
 
 # Install Go tools
 ENV GO111MODULE=auto
-COPY library-scripts/go-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/go-debian.sh "none" "/usr/local/go" "${GOPATH}" "node" "false" \
-    && apt-get clean -y && rm -rf /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+RUN rm -rf /tmp/library-scripts
 
 # Add Tini
 ENV TINI_VERSION v0.19.0
@@ -141,7 +144,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
 ##############################
-FROM base
+FROM dev-env
 
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -151,12 +154,13 @@ ENV SDK_SRC=/src
 ENV OUTPUT_DIR=/out
 ENV SDK_REVISION=
 ENV SDK_BUILD=0
+ENV NVM_RC_VERSION=
 
 WORKDIR /app
 COPY --chown=$USER_UID:$USER_GID . .
 
 RUN mkdir -p $SDK_SRC $OUTPUT_DIR && chown $USER_UID:$USER_GID $SDK_SRC $OUTPUT_DIR /app
 
-USER $USER_UID:$USER_GID
+USER $USER_UID
 
 ENTRYPOINT ["/tini", "--", "/app/start.sh", "--no-reset", "--test-data.docker"]

--- a/library-scripts/go-debian.sh
+++ b/library-scripts/go-debian.sh
@@ -4,7 +4,8 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/go.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/go.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./go-debian.sh [Go version] [GOROOT] [GOPATH] [non-root user] [Add GOPATH, GOROOT to rc files flag] [Install tools flag]
 
@@ -14,6 +15,9 @@ TARGET_GOPATH=${3:-"/go"}
 USERNAME=${4:-"automatic"}
 UPDATE_RC=${5:-"true"}
 INSTALL_GO_TOOLS=${6:-"true"}
+
+# https://www.google.com/linuxrepositories/
+GO_GPG_KEY_URI="https://dl.google.com/linux/linux_signing_key.pub"
 
 set -e
 
@@ -44,61 +48,144 @@ elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
     USERNAME=root
 fi
 
-function updaterc() {
+updaterc() {
     if [ "${UPDATE_RC}" = "true" ]; then
         echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc..."
-        echo -e "$1" >> /etc/bash.bashrc
-        if [ -f "/etc/zsh/zshrc" ]; then
+        if [[ "$(cat /etc/bash.bashrc)" != *"$1"* ]]; then
+            echo -e "$1" >> /etc/bash.bashrc
+        fi
+        if [ -f "/etc/zsh/zshrc" ] && [[ "$(cat /etc/zsh/zshrc)" != *"$1"* ]]; then
             echo -e "$1" >> /etc/zsh/zshrc
         fi
+    fi
+}
+# Figure out correct version of a three part version number is not passed
+find_version_from_git_tags() {
+    local variable_name=$1
+    local requested_version=${!variable_name}
+    if [ "${requested_version}" = "none" ]; then return; fi
+    local repository=$2
+    local prefix=${3:-"tags/v"}
+    local separator=${4:-"."}
+    local last_part_optional=${5:-"false"}    
+    if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
+        local escaped_separator=${separator//./\\.}
+        local last_part
+        if [ "${last_part_optional}" = "true" ]; then
+            last_part="(${escaped_separator}[0-9]+)?"
+        else
+            last_part="${escaped_separator}[0-9]+"
+        fi
+        local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
+        local version_list="$(git ls-remote --tags ${repository} | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
+        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
+            declare -g ${variable_name}="$(echo "${version_list}" | head -n 1)"
+        else
+            set +e
+            declare -g ${variable_name}="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
+            set -e
+        fi
+    fi
+    if [ -z "${!variable_name}" ] || ! echo "${version_list}" | grep "^${!variable_name//./\\.}$" > /dev/null 2>&1; then
+        echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
+        exit 1
+    fi
+    echo "${variable_name}=${!variable_name}"
+}
+
+# Get central common setting
+get_common_setting() {
+    if [ "${common_settings_file_loaded}" != "true" ]; then
+        curl -sfL "https://aka.ms/vscode-dev-containers/script-library/settings.env" 2>/dev/null -o /tmp/vsdc-settings.env || echo "Could not download settings file. Skipping."
+        common_settings_file_loaded=true
+    fi
+    if [ -f "/tmp/vsdc-settings.env" ]; then
+        local multi_line=""
+        if [ "$2" = "true" ]; then multi_line="-z"; fi
+        local result="$(grep ${multi_line} -oP "$1=\"?\K[^\"]+" /tmp/vsdc-settings.env | tr -d '\0')"
+        if [ ! -z "${result}" ]; then declare -g $1="${result}"; fi
+    fi
+    echo "$1=${!1}"
+}
+
+# Function to run apt-get if needed
+apt_get_update_if_needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        apt_get_update_if_needed
+        apt-get -y install --no-install-recommends "$@"
     fi
 }
 
 export DEBIAN_FRONTEND=noninteractive
 
 # Install curl, tar, git, other dependencies if missing
-if ! dpkg -s curl ca-certificates tar git g++ gcc libc6-dev make pkg-config > /dev/null 2>&1; then
-    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
-        apt-get update
-    fi
-    apt-get -y install --no-install-recommends curl ca-certificates tar git g++ gcc libc6-dev make pkg-config
+check_packages curl ca-certificates gnupg2 tar g++ gcc libc6-dev make pkg-config
+if ! type git > /dev/null 2>&1; then
+    apt_get_update_if_needed
+    apt-get -y install --no-install-recommends git
 fi
 
-# Get latest version number if latest is specified
-if [ "${TARGET_GO_VERSION}" = "latest" ] ||  [ "${TARGET_GO_VERSION}" = "current" ] ||  [ "${TARGET_GO_VERSION}" = "lts" ]; then
-    TARGET_GO_VERSION=$(curl -sSL "https://golang.org/VERSION?m=text" | sed -n '/^go/s///p' )
-fi
+# Get closest match for version number specified
+find_version_from_git_tags TARGET_GO_VERSION "https://go.googlesource.com/go" "tags/go" "." "true"
+
+architecture="$(uname -m)"
+case $architecture in
+    x86_64) architecture="amd64";;
+    aarch64 | armv8*) architecture="arm64";;
+    aarch32 | armv7* | armvhf*) architecture="armv6l";;
+    i?86) architecture="386";;
+    *) echo "(!) Architecture $architecture unsupported"; exit 1 ;;
+esac
 
 # Install Go
-GO_INSTALL_SCRIPT="$(cat <<EOF
-    set -e
+umask 0002
+if ! cat /etc/group | grep -e "^golang:" > /dev/null 2>&1; then
+    groupadd -r golang
+fi
+usermod -a -G golang "${USERNAME}"
+mkdir -p "${TARGET_GOROOT}" "${TARGET_GOPATH}" 
+if [ "${TARGET_GO_VERSION}" != "none" ] && ! type go > /dev/null 2>&1; then
+    # Use a temporary locaiton for gpg keys to avoid polluting image
+    export GNUPGHOME="/tmp/tmp-gnupg"
+    mkdir -p ${GNUPGHOME}
+    chmod 700 ${GNUPGHOME}
+    get_common_setting GO_GPG_KEY_URI
+    curl -sSL -o /tmp/tmp-gnupg/golang_key "${GO_GPG_KEY_URI}"
+    gpg -q --import /tmp/tmp-gnupg/golang_key
     echo "Downloading Go ${TARGET_GO_VERSION}..."
-    curl -sSL -o /tmp/go.tar.gz "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-amd64.tar.gz"
+    curl -sSL -o /tmp/go.tar.gz "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz"
+    curl -sSL -o /tmp/go.tar.gz.asc "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz.asc"
+    gpg --verify /tmp/go.tar.gz.asc /tmp/go.tar.gz
     echo "Extracting Go ${TARGET_GO_VERSION}..."
     tar -xzf /tmp/go.tar.gz -C "${TARGET_GOROOT}" --strip-components=1
-    rm -f /tmp/go.tar.gz
-EOF
-)"
-if [ "${TARGET_GO_VERSION}" != "none" ] && ! type go > /dev/null 2>&1; then
-    mkdir -p "${TARGET_GOROOT}" "${TARGET_GOPATH}" 
-    chown -R ${USERNAME} "${TARGET_GOROOT}" "${TARGET_GOPATH}"
-    su ${USERNAME} -c "${GO_INSTALL_SCRIPT}"
+    rm -rf /tmp/go.tar.gz /tmp/go.tar.gz.asc /tmp/tmp-gnupg
 else
     echo "Go already installed. Skipping."
 fi
 
 # Install Go tools that are isImportant && !replacedByGopls based on
-# https://github.com/golang/vscode-go/blob/0c6dce4a96978f61b022892c1376fe3a00c27677/src/goTools.ts#L188
-# exception: golangci-lint is installed using their install script below.
+# https://github.com/golang/vscode-go/blob/0ff533d408e4eb8ea54ce84d6efa8b2524d62873/src/goToolsInformation.ts
+# Exception `dlv-dap` is a copy of github.com/go-delve/delve/cmd/dlv built from the master.
 GO_TOOLS="\
-    golang.org/x/tools/gopls \
-    honnef.co/go/tools/... \
-    golang.org/x/lint/golint \
-    github.com/mgechev/revive \
-    github.com/uudashr/gopkgs/v2/cmd/gopkgs \
-    github.com/ramya-rao-a/go-outline \
-    github.com/go-delve/delve/cmd/dlv \
-    github.com/golangci/golangci-lint/cmd/golangci-lint"
+    golang.org/x/tools/gopls@latest \
+    honnef.co/go/tools/cmd/staticcheck@latest \
+    golang.org/x/lint/golint@latest \
+    github.com/mgechev/revive@latest \
+    github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest \
+    github.com/ramya-rao-a/go-outline@latest \
+    github.com/go-delve/delve/cmd/dlv@latest \
+    github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
 if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     echo "Installing common Go tools..."
     export PATH=${TARGET_GOROOT}/bin:${PATH}
@@ -107,14 +194,24 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     export GOPATH=/tmp/gotools
     export GOCACHE=/tmp/gotools/cache
 
-    # Go tools w/module support
-    export GO111MODULE=on
-    (echo "${GO_TOOLS}" | xargs -n 1 go get -v )2>&1 | tee -a /usr/local/etc/vscode-dev-containers/go.log
+    # Use go get for versions of go under 1.16
+    go_install_command=install
+    if [[ "1.16" > "$(go version | grep -oP 'go\K[0-9]+\.[0-9]+(\.[0-9]+)?')" ]]; then
+        export GO111MODULE=on
+        go_install_command=get
+        echo "Go version < 1.16, using go get."
+    fi 
+
+    (echo "${GO_TOOLS}" | xargs -n 1 go ${go_install_command} -v )2>&1 | tee -a /usr/local/etc/vscode-dev-containers/go.log
 
     # Move Go tools into path and clean up
     mv /tmp/gotools/bin/* ${TARGET_GOPATH}/bin/
+
+    # install dlv-dap (dlv@master)
+    go ${go_install_command} -v github.com/go-delve/delve/cmd/dlv@master 2>&1 | tee -a /usr/local/etc/vscode-dev-containers/go.log
+    mv /tmp/gotools/bin/dlv ${TARGET_GOPATH}/bin/dlv-dap
+
     rm -rf /tmp/gotools
-    chown -R ${USERNAME} "${TARGET_GOPATH}"
 fi
 
 # Add GOPATH variable and bin directory into PATH in bashrc/zshrc files (unless disabled)
@@ -125,5 +222,10 @@ export GOROOT="${TARGET_GOROOT}"
 if [[ "\${PATH}" != *"\${GOROOT}/bin"* ]]; then export PATH="\${PATH}:\${GOROOT}/bin"; fi
 EOF
 )"
+
+chown -R :golang "${TARGET_GOROOT}" "${TARGET_GOPATH}"
+chmod -R g+r+w "${TARGET_GOROOT}" "${TARGET_GOPATH}"
+find "${TARGET_GOROOT}" -type d | xargs -n 1 chmod g+s
+find "${TARGET_GOPATH}" -type d | xargs -n 1 chmod g+s
 
 echo "Done!"

--- a/loadgen/firebase/admin/package.json
+++ b/loadgen/firebase/admin/package.json
@@ -39,8 +39,5 @@
     "trailingComma": "all",
     "singleQuote": true
   },
-  "engines": {
-    "node": "14"
-  },
   "private": true
 }

--- a/loadgen/firebase/firebase.json
+++ b/loadgen/firebase/firebase.json
@@ -3,6 +3,7 @@
     "rules": "database.rules.json"
   },
   "functions": {
+    "runtime": "nodejs14",
     "source": "admin/"
   }
 }

--- a/runner/lib/entrypoint.js
+++ b/runner/lib/entrypoint.js
@@ -48,7 +48,7 @@ process.on('uncaughtException', (error) => {
         spawn,
         tmpDir,
       }),
-    async () => fs.rmdir(tmpDir, { recursive: true }),
+    async () => (fs.rm || fs.rmdir)(tmpDir, { recursive: true }),
   );
 })().then(
   (res) => {

--- a/runner/lib/helpers/async.d.ts
+++ b/runner/lib/helpers/async.d.ts
@@ -17,7 +17,7 @@ export declare function warnOnRejection(
 
 export declare function aggregateTryFinally<T>(
   trier: () => Promise<T>,
-  finalizer: () => Promise<void>,
+  finalizer: (error?: unknown) => Promise<void>,
 ): Promise<T>;
 
 export declare function tryTimeout<T>(

--- a/runner/lib/helpers/async.js
+++ b/runner/lib/helpers/async.js
@@ -84,7 +84,7 @@ export const aggregateTryFinally = async (trier, finalizer) =>
   trier().then(
     async (result) => finalizer().then(() => result),
     async (tryError) =>
-      finalizer()
+      finalizer(tryError)
         .then(
           () => tryError,
           (finalizeError) => makeAggregateError([tryError, finalizeError]),

--- a/runner/lib/helpers/elided-buffer-line-transform.d.ts
+++ b/runner/lib/helpers/elided-buffer-line-transform.d.ts
@@ -1,0 +1,18 @@
+/* eslint-disable no-undef,no-unused-vars */
+
+import BufferLineTransform from './buffer-line-transform.js';
+import type { BufferLineTransformOptions } from './buffer-line-transform.js';
+
+export interface ElidedBufferLineTransformOptions
+  extends BufferLineTransformOptions {
+  /** Maximum length of a line (default: 1152) */
+  maxLineLength?: number;
+  /** Location in the line where to start removing data from (default: maxLineLength / 2) */
+  elisionOffset?: number;
+  /** The Buffer to use when stitching the line back together (default: Buffer.from('...')) */
+  elisionJoiner?: Buffer;
+}
+
+export default class ElidedBufferLineTransform extends BufferLineTransform {
+  constructor(options?: ElidedBufferLineTransformOptions);
+}

--- a/runner/lib/helpers/elided-buffer-line-transform.js
+++ b/runner/lib/helpers/elided-buffer-line-transform.js
@@ -1,0 +1,55 @@
+/* global Buffer */
+/* eslint-disable no-underscore-dangle */
+
+import BufferLineTransform from './buffer-line-transform.js';
+
+export default class ElidedBufferLineTransform extends BufferLineTransform {
+  /**
+   * The ElidedBufferLineTransform is a BufferLineTransform which cuts long lines
+   * by eliding data at a given position
+   *
+   * @param {import('./elided-buffer-line-transform.js').ElidedBufferLineTransformOptions} [options]
+   */
+  constructor(options) {
+    const {
+      maxLineLength = 1152,
+      elisionOffset,
+      elisionJoiner = Buffer.from('...'),
+      ...superOptions
+    } = options || {};
+    super(superOptions);
+
+    const minLength =
+      /** @type {{_breakLength: number}} */ (/** @type {unknown} */ (this))
+        ._breakLength + elisionJoiner.length;
+    this._maxLineLength = Math.max(minLength, maxLineLength);
+    this._elisionJoiner = elisionJoiner;
+    this._elisionOffset = Math.max(
+      0,
+      Math.min(
+        this._maxLineLength - minLength,
+        elisionOffset != null
+          ? elisionOffset
+          : Math.round((this._maxLineLength - elisionJoiner.length) / 2),
+      ),
+    );
+  }
+
+  /**
+   * @param {Buffer} line
+   */
+  _writeItem(line) {
+    if (line.length > this._maxLineLength) {
+      line = Buffer.concat([
+        line.subarray(0, this._elisionOffset),
+        this._elisionJoiner,
+        line.subarray(
+          this._elisionOffset +
+            this._elisionJoiner.length -
+            this._maxLineLength,
+        ),
+      ]);
+    }
+    this.push(line);
+  }
+}

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -206,7 +206,7 @@ const main = async (progName, rawArgs, powers) => {
   const argv = yargsParser(rawArgs);
 
   const { getProcessInfo, getCPUTimeOffset } = makeProcfsHelper({ fs, spawn });
-  const { findByPrefix, dirDiskUsage, makeFIFO } = makeFsHelper({
+  const { dirDiskUsage, makeFIFO } = makeFsHelper({
     fs,
     fsStream,
     spawn,
@@ -297,7 +297,6 @@ const main = async (progName, rawArgs, powers) => {
     {
       spawn,
       fs,
-      findDirByPrefix: findByPrefix,
       makeFIFO,
       getProcessInfo,
       sdkBinaries,

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -803,7 +803,7 @@ const main = async (progName, rawArgs, powers) => {
       const withMonitor = coerceBooleanOption(argv.monitor, true);
       const globalChainOnly = coerceBooleanOption(argv.chainOnly, undefined);
       {
-        const { releaseInterrupt } = makeInterrupterKit({
+        const { orInterrupt, releaseInterrupt } = makeInterrupterKit({
           console: initConsole,
         });
 
@@ -818,7 +818,12 @@ const main = async (progName, rawArgs, powers) => {
         await aggregateTryFinally(
           // Do not short-circuit on interrupt, let the spawned setup process terminate
           async () =>
-            setupTasks({ stdout: out, stderr: err, config: setupConfig }),
+            setupTasks({
+              stdout: out,
+              stderr: err,
+              orInterrupt,
+              config: setupConfig,
+            }),
 
           // This will throw if there was any interrupt, and prevent further execution
           async () => releaseInterrupt(),

--- a/runner/lib/monitor/chain-monitor.js
+++ b/runner/lib/monitor/chain-monitor.js
@@ -8,7 +8,7 @@ import { PromiseAllOrErrors, warnOnRejection } from '../helpers/async.js';
 const vatIdentifierRE = /^(v\d+):(.*)$/;
 
 /**
- * @param {Pick<import("../tasks/types.js").RunChainInfo, 'storageLocation' | 'processInfo'>} chainInfo
+ * @param {Pick<import("../tasks/types.js").RunKernelInfo, 'storageLocation' | 'processInfo'>} kernelInfo
  * @param {Object} param1
  * @param {Console} param1.console
  * @param {import('../stats/types.js').LogPerfEvent} param1.logPerfEvent

--- a/runner/lib/monitor/slog-monitor.js
+++ b/runner/lib/monitor/slog-monitor.js
@@ -140,7 +140,7 @@ const activeEventRE = filterSlogEvent([
 ]);
 
 /**
- * @param {Pick<import("../tasks/types.js").RunChainInfo, 'slogLines'>} chainInfo
+ * @param {Pick<import("../tasks/types.js").RunKernelInfo, 'slogLines'>} chainInfo
  * @param {Object} param1
  * @param {StageStats} param1.stats
  * @param {{blockDone(block: BlockStats): void}} [param1.notifier]

--- a/runner/lib/tasks/helpers.js
+++ b/runner/lib/tasks/helpers.js
@@ -20,6 +20,15 @@ const protocolModules = {
 /** @typedef {http.RequestOptions & {body?: Buffer}} HTTPRequestOptions */
 
 /**
+ * @template T
+ * @param {AsyncIterable<T>} iterable
+ * @returns {AsyncIterable<T>}
+ */
+export const cleanAsyncIterable = (iterable) => ({
+  [Symbol.asyncIterator]: () => iterable[Symbol.asyncIterator](),
+});
+
+/**
  * @param {string | URL} urlOrString
  * @param {HTTPRequestOptions} [options]
  * @returns {Promise<http.IncomingMessage>}
@@ -34,7 +43,7 @@ export const httpRequest = (urlOrString, options = {}) => {
       // Ugly cast hack to make res look like what the consumer cares about
       const res = /** @type {http.IncomingMessage} */ (harden(
         /** @type {unknown} */ ({
-          [Symbol.asyncIterator]: () => stream[Symbol.asyncIterator](),
+          ...cleanAsyncIterable(stream),
           statusCode: 200,
         }),
       ));

--- a/runner/lib/tasks/local-chain.js
+++ b/runner/lib/tasks/local-chain.js
@@ -418,7 +418,7 @@ export const makeTasks = ({
   };
 
   return harden({
-    getEnvInfo: makeGetEnvInfo({ spawn }),
+    getEnvInfo: makeGetEnvInfo({ spawn, sdkBinaries }),
     setupTasks,
     runChain,
     runClient,

--- a/runner/lib/tasks/shared-loadgen.js
+++ b/runner/lib/tasks/shared-loadgen.js
@@ -10,7 +10,11 @@ import {
 import LineStreamTransform from '../helpers/line-stream-transform.js';
 import { PromiseAllOrErrors, tryTimeout } from '../helpers/async.js';
 import { whenStreamSteps } from '../helpers/stream.js';
-import { httpRequest, getConsoleAndStdio } from './helpers.js';
+import {
+  httpRequest,
+  getConsoleAndStdio,
+  cleanAsyncIterable,
+} from './helpers.js';
 
 const pipeline = promisify(pipelineCallback);
 
@@ -153,9 +157,7 @@ export const makeLoadgenTask = ({ spawn }) => {
           done,
           ready,
           updateConfig,
-          taskEvents: {
-            [Symbol.asyncIterator]: () => taskEvents[Symbol.asyncIterator](),
-          },
+          taskEvents: cleanAsyncIterable(taskEvents),
         });
       },
       async () => {

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -237,7 +237,7 @@ export const makeTasks = ({
 
       const soloAddr = (
         await fs.readFile(`${clientStateDir}/ag-cosmos-helper-address`, 'utf-8')
-      ).trimRight();
+      ).trimEnd();
 
       const rpcAddrCandidates = [...rpcAddrs];
       let rpcAddr;
@@ -312,8 +312,6 @@ ${chainName} chain does not yet know of address ${soloAddr}
 
       await tryTimeout(timeout * 1000, untilProvisioned);
     }
-
-    await childProcessDone(printerSpawn('agoric', ['install'], { stdio }));
 
     console.log('Done');
   };

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -439,7 +439,7 @@ export const makeTasks = ({
   };
 
   return harden({
-    getEnvInfo: makeGetEnvInfo({ spawn }),
+    getEnvInfo: makeGetEnvInfo({ spawn, sdkBinaries }),
     setupTasks,
     runChain,
     runClient,

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -14,6 +14,7 @@ import {
   childProcessReady,
 } from '../helpers/child-process.js';
 import BufferLineTransform from '../helpers/buffer-line-transform.js';
+import ElidedBufferLineTransform from '../helpers/elided-buffer-line-transform.js';
 import { PromiseAllOrErrors, tryTimeout, sleep } from '../helpers/async.js';
 import { fsStreamReady } from '../helpers/fs.js';
 import { asBuffer, whenStreamSteps } from '../helpers/stream.js';
@@ -367,9 +368,11 @@ ${chainName} chain does not yet know of address ${soloAddr}
         }
       });
 
-    chainCp.stdout.pipe(stdio[1], { end: false });
+    const chainElidedOutput = new ElidedBufferLineTransform();
+    chainCp.stdout.pipe(chainElidedOutput);
+    chainElidedOutput.pipe(stdio[1], { end: false });
     const [swingSetLaunched, firstBlock, outputParsed] = whenStreamSteps(
-      chainCp.stdout,
+      chainElidedOutput,
       [
         { matcher: chainSwingSetLaunchRE },
         { matcher: chainBlockBeginRE, resultIndex: -1 },
@@ -495,9 +498,11 @@ ${chainName} chain does not yet know of address ${soloAddr}
         }
       });
 
-    soloCp.stdout.pipe(stdio[1], { end: false });
+    const soloElidedOutput = new ElidedBufferLineTransform();
+    soloCp.stdout.pipe(soloElidedOutput);
+    soloElidedOutput.pipe(stdio[1], { end: false });
     const [clientStarted, walletReady, outputParsed] = whenStreamSteps(
-      soloCp.stdout,
+      soloElidedOutput,
       [
         { matcher: clientSwingSetReadyRE, resultIndex: -1 },
         { matcher: clientWalletReadyRE, resultIndex: -1 },

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -370,7 +370,7 @@ export const makeTasks = ({
   };
 
   /** @param {import("./types.js").TaskBaseOptions} options */
-  const runClient = async ({ stdout, stderr, timeout = 20 }) => {
+  const runClient = async ({ stdout, stderr, timeout = 60 }) => {
     const { console, stdio } = getConsoleAndStdio('client', stdout, stderr);
     const printerSpawn = makePrinterSpawn({
       spawn,

--- a/runner/lib/tasks/types.d.ts
+++ b/runner/lib/tasks/types.d.ts
@@ -19,7 +19,7 @@ export type TaskResult = {
   readonly ready: Promise<void>;
 };
 
-export type RunChainInfo = {
+export type RunKernelInfo = {
   readonly slogLines: AsyncIterable<Buffer>;
   readonly processInfo: import('../helpers/process-info.js').ProcessInfo;
   readonly storageLocation: string;
@@ -52,7 +52,8 @@ export type RunLoadgenInfo = {
   updateConfig(newConfig: unknown): Promise<void>;
 };
 
-export type RunChainResult = TaskResult & RunChainInfo;
+export type RunChainResult = TaskResult & RunKernelInfo;
+export type RunClientResult = TaskResult & RunKernelInfo;
 export type RunLoadgenResult = TaskResult & RunLoadgenInfo;
 
 export interface TaskBaseOptions {
@@ -66,6 +67,6 @@ export interface OrchestratorTasks {
   getEnvInfo(options: TaskBaseOptions): Promise<EnvInfo>;
   setupTasks(options: TaskBaseOptions): Promise<void>;
   runChain(options: TaskBaseOptions): Promise<RunChainResult>;
-  runClient(options: TaskBaseOptions): Promise<TaskResult>;
+  runClient(options: TaskBaseOptions): Promise<RunClientResult>;
   runLoadgen(options: TaskBaseOptions): Promise<RunLoadgenResult>;
 }

--- a/runner/lib/tasks/types.d.ts
+++ b/runner/lib/tasks/types.d.ts
@@ -60,6 +60,7 @@ export interface TaskBaseOptions {
   readonly stdout: import('stream').Writable;
   readonly stderr: import('stream').Writable;
   readonly timeout?: number;
+  readonly orInterrupt?: (job?: Promise<any>) => Promise<any>;
   readonly config?: unknown;
 }
 

--- a/runner/package.json
+++ b/runner/package.json
@@ -36,7 +36,7 @@
     "deterministic-json": "^1.0.5",
     "inquirer": "^6.3.1",
     "readline-transform": "^1.0.0",
-    "ses": "^0.14.0",
+    "ses": "^0.15.1",
     "yargs-parser": "^20.2.2"
   },
   "keywords": [],

--- a/start.sh
+++ b/start.sh
@@ -66,7 +66,7 @@ fi
 
 cd "$SDK_SRC"
 if [ "x$SDK_BUILD" != "x0" ]; then
-    yarn install
+    yarn install --frozen-lockfile
     yarn build
     make -C packages/cosmic-swingset
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 set -e -x
 
-
-LOADGEN_DIR="$(pwd)"
+LOADGEN_DIR="$(dirname "$(readlink -f -- "$0")")"
 
 SDK_REPO="${SDK_REPO:-https://github.com/Agoric/agoric-sdk.git}"
 
@@ -43,6 +42,27 @@ OUTPUT_DIR="${OUTPUT_DIR:-/tmp/agoric-sdk-out-${SDK_REVISION}}"
 mkdir -p "${OUTPUT_DIR}"
 
 export PATH="$AGORIC_BIN_DIR:$PATH"
+
+if [ ! -f "${OUTPUT_DIR}/.nvmrc" ] ; then
+    SDK_NODE16_REVISION=475d7ff1eb2371aa9e0c0dc7a50644089db351f6
+    if ! git -C "${SDK_SRC}" merge-base --is-ancestor $SDK_NODE16_REVISION $SDK_FULL_REVISION ; then
+        echo "lts/fermium" > "${OUTPUT_DIR}/.nvmrc"
+    fi
+    if [ -n "$NVM_RC_VERSION" ]; then 
+        echo "$NVM_RC_VERSION" > "${OUTPUT_DIR}/.nvmrc"
+    fi
+fi
+
+if [ -f "${OUTPUT_DIR}/.nvmrc" ] ; then
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+    export NVM_SYMLINK_CURRENT=false
+    cd "${OUTPUT_DIR}"
+    if [ "$(nvm version "$(cat ".nvmrc")")" = "N/A" ]; then
+        nvm install
+    fi
+    nvm use
+    cd -
+fi
 
 cd "$SDK_SRC"
 if [ "x$SDK_BUILD" != "x0" ]; then

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,680 +2,397 @@
 # yarn lockfile v1
 
 
-"@agoric/acorn-eventual-send@^2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@agoric/acorn-eventual-send/-/acorn-eventual-send-2.1.6.tgz#f870157639235b2ff4652ed5d2faad46a57fa466"
-  integrity sha512-9uaLuAWKwZsno+6e/5+CZ1ePluNZEYmows+QBmqnC89CqtHmpa2b75G5XU+guUGmgExm0jKaP2zYhpdqM8dhGQ==
-
-"@agoric/assert@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.2.6.tgz#d76827aa891838fb9d8fd075b1130dc2320bbf59"
-  integrity sha512-oGktC9/1U+LDfEUuzByP/Ehsu4wHMh+TH+9GwbgB3H1cB1ARIuLKYP3Se6JrKV0XaeEPMCNZ0BA3EcuUSeSjCQ==
+"@agoric/access-token@^0.4.16":
+  version "0.4.16"
+  resolved "https://registry.yarnpkg.com/@agoric/access-token/-/access-token-0.4.16.tgz#33810f3cb481c95b9a84bc6d6ac32dc5a11e90c6"
+  integrity sha512-SoUafgebn5qwwc3IBbdtFINqehYfEn9HFg59ovl04gXke6Ao62es3ZqFhJobpc8zlyqXd0KVwIfMG7Y52UaYwg==
   dependencies:
-    ses "^0.12.7"
+    "@agoric/assert" "^0.3.15"
+    n-readlines "^1.0.0"
 
-"@agoric/assert@^0.3.7":
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.3.7.tgz#ccee9e4f1eb6412fe977fa8b887b6224ef901dfa"
-  integrity sha512-vzNdcFeO/1SMazEGXrdKjutUVP1RVBoDv2L8DvMoVay7NRiV93A0OKvn3f1Xe6HPGRyTQJz3XBmgLKlR1FJYBg==
-  dependencies:
-    ses "^0.13.4"
-
-"@agoric/babel-parser@^7.6.4":
-  version "7.9.4"
-  resolved "https://registry.yarnpkg.com/@agoric/babel-parser/-/babel-parser-7.9.4.tgz#2f9fd67f75a4a00bd1853e9d625bcc8ed479a564"
-  integrity sha512-m/3AWP71douAzBIMWAkrZnFpFTZpeRNph6bwEhjJ9RZYI+QtmLbf1ipIJLFaeRMfo5NGB6hVa/SbSCKGnPEpuQ==
+"@agoric/assert@^0.3.15":
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.3.15.tgz#149d120790b76bb79ca9a02f265d8e7a8a904a87"
+  integrity sha512-6Kb0mtRoAd3O3VwnEXnGpy+ldqD+nB4OSZdgfKZkGn+apN9nLQP4OStEZKeG+jWsgBIzpNE61LrXv6HnBMCX+Q==
 
 "@agoric/babel-standalone@^7.14.3":
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.14.3.tgz#1bf201417481d37d2797dd3283590dcbef775b4d"
   integrity sha512-Rdlxts19kvxHsqTjTrhGJv0yKgCyjCSVgXoLBZf9dZ7lyo/j+6xFQBiWjP03bXve3X74wUvA1QU55wVey8DEiQ==
 
-"@agoric/babel-standalone@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.9.5.tgz#1ca0c17844924199d31e49d6b67e8b2a629b8599"
-  integrity sha512-1Aa23oPuRi4kywUyZODo8zey9Gq2NpD2xUnNvgJLoT8orMQRlVOtvbG3JeHq5sjJERlF/q6csg4/P8t8/5IABA==
-
-"@agoric/bundle-source@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@agoric/bundle-source/-/bundle-source-1.3.1.tgz#f1dc2dda056da5453be1661f35baebd99019afa1"
-  integrity sha512-grYn+lozkbhhyRN5d67iMENjDqELpYzKW0uWXcWAHBk65AvKXNZxMfLTVwXRgolyTm91U8Lqbab6pmu6fUJ2MA==
+"@agoric/bundle-source@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@agoric/bundle-source/-/bundle-source-2.0.1.tgz#30a030e5a2f934994280b4f1e489af3c39ef94e1"
+  integrity sha512-3y3ZDNKNa2oWaWq8bXGtEJiVrSzVoZjZXOgFXP3GAHYnHiS9woRigvtnOu01ZFxDgpDMjLGjcXRVUK3GdYfhWA==
   dependencies:
-    "@agoric/acorn-eventual-send" "^2.1.6"
-    "@agoric/babel-parser" "^7.6.4"
-    "@agoric/compartment-mapper" "^0.2.4"
-    "@agoric/transform-eventual-send" "^1.4.6"
-    "@babel/generator" "^7.6.4"
-    "@babel/traverse" "^7.8.3"
-    "@endo/base64" "^0.1.0"
-    "@rollup/plugin-commonjs" "~11.0.2"
-    "@rollup/plugin-node-resolve" "^7.1.1"
-    acorn "^7.1.0"
-    esm "^3.2.5"
-    rollup "^1.32.0"
-    ses "^0.12.6"
-    source-map "^0.7.3"
-
-"@agoric/bundle-source@^1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@agoric/bundle-source/-/bundle-source-1.4.5.tgz#6f18fd1ceb3a649850ed6897fba9e55a39352b1e"
-  integrity sha512-NkPV4ap8QpU0KPaVpGlzF+vI5jmF2aeY706mcZ4P4zpXO9tvGJQPu5jY5cGDr3EjD+TAv1nwfpztJUQRiUYVzg==
-  dependencies:
-    "@agoric/babel-standalone" "^7.14.3"
     "@babel/generator" "^7.14.2"
     "@babel/parser" "^7.14.2"
     "@babel/traverse" "^7.14.2"
-    "@endo/base64" "^0.2.4"
-    "@endo/compartment-mapper" "^0.4.1"
+    "@endo/base64" "^0.2.8"
+    "@endo/compartment-mapper" "^0.5.3"
     "@rollup/plugin-commonjs" "^19.0.0"
     "@rollup/plugin-node-resolve" "^13.0.0"
     acorn "^8.2.4"
     c8 "^7.7.2"
     rollup "^2.47.0"
-    ses "^0.13.4"
     source-map "^0.7.3"
 
-"@agoric/captp@^1.7.6":
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/@agoric/captp/-/captp-1.7.6.tgz#06b4f105781ced85951ba8d4957b15a7ec4bd94b"
-  integrity sha512-1DNWvGQl+V9DHSS0qNqj1fN9LzSPQ4bqBENUagJNDVzwfOrtAEEVXkZNXTWB1bXotQcEl9Sx6mb1MbBfiqGMZg==
+"@agoric/captp@^1.10.7":
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/@agoric/captp/-/captp-1.10.7.tgz#ec55ba550f21886fcf9a1eeb6abebecbdedf6dfc"
+  integrity sha512-fJirXSIR+OOp97wpaJ6LXS/E5mmFSoQypPQeKdYdERV8wQsY7bSjDMa2mfbqVKNDZ+txAzVvVXieASYet+GaUg==
   dependencies:
-    "@agoric/eventual-send" "^0.13.6"
-    "@agoric/marshal" "^0.4.3"
-    "@agoric/nat" "^4.0.0"
-    "@agoric/promise-kit" "^0.2.6"
-    esm "^3.2.5"
-
-"@agoric/captp@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@agoric/captp/-/captp-1.8.0.tgz#75f0bbdfba807f86925ca380c73e31b0ce9466e3"
-  integrity sha512-ZwxfKg1C3ENnGWBUskZhHdpw7NEwmVR7yQLrbybkWFDLRarOOZc2PLNUMxbiPyNt+u0ngoWGKa39kVU1YqvIow==
-  dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@agoric/eventual-send" "^0.13.23"
-    "@agoric/marshal" "^0.4.20"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/marshal" "^0.5.0"
     "@agoric/nat" "^4.1.0"
-    "@agoric/promise-kit" "^0.2.21"
+    "@agoric/promise-kit" "^0.2.29"
 
-"@agoric/compartment-mapper@^0.2.3", "@agoric/compartment-mapper@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@agoric/compartment-mapper/-/compartment-mapper-0.2.4.tgz#db78b3d3c34db2204aba6eaa29155a3e0a371e73"
-  integrity sha512-HppJtvTQP9R/a55dX+7H4xXYlj6oPmvN9xVvWVk+BDEq0//AiS1/3qpV+R6B34raNvBPatsBzYuhZQjdHSw3+A==
+"@agoric/cosmic-swingset@*":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@agoric/cosmic-swingset/-/cosmic-swingset-0.34.3.tgz#b637c31520f3b666462a1cb9d94d50ede2d55987"
+  integrity sha512-GfqK3AyhCgNT0+c21O/wmaUlq0DDpvwH39RfqFOxd6P5Y7ldxe+Lpy4nlMJBb2NnPKO256BguI+1g605IbeF5Q==
   dependencies:
-    ses "^0.12.6"
-
-"@agoric/cosmic-swingset@*", "@agoric/cosmic-swingset@^0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@agoric/cosmic-swingset/-/cosmic-swingset-0.29.0.tgz#29b0cc3692e98d67ae16682dc5f8ebf534f308c5"
-  integrity sha512-yGwxqB7tIWUHDW2o6TRO79coP6r6F89GexxNJkaADceVny1Sn2TyOsR8RmgyLhUSP9bWeQ4PosQr7wpgnoARZw==
-  dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/babel-parser" "^7.6.4"
-    "@agoric/bundle-source" "^1.3.1"
-    "@agoric/captp" "^1.7.6"
-    "@agoric/cosmos" "^0.25.0"
-    "@agoric/dapp-svelte-wallet" "^0.9.0"
-    "@agoric/ertp" "^0.10.4"
-    "@agoric/eventual-send" "^0.13.7"
-    "@agoric/import-bundle" "^0.2.7"
-    "@agoric/install-metering-and-ses" "^0.2.6"
-    "@agoric/install-ses" "^0.5.6"
-    "@agoric/marshal" "^0.4.4"
-    "@agoric/nat" "^4.0.0"
-    "@agoric/notifier" "^0.3.7"
-    "@agoric/pegasus" "^0.2.0"
-    "@agoric/promise-kit" "^0.2.6"
-    "@agoric/registrar" "^0.2.7"
-    "@agoric/same-structure" "^0.1.6"
-    "@agoric/sharing-service" "^0.1.7"
-    "@agoric/sparse-ints" "^0.1.6"
-    "@agoric/spawner" "^0.4.7"
-    "@agoric/store" "^0.4.7"
-    "@agoric/swing-store-lmdb" "^0.4.6"
-    "@agoric/swing-store-simple" "^0.3.6"
-    "@agoric/swingset-vat" "^0.16.0"
-    "@agoric/transform-eventual-send" "^1.4.6"
-    "@agoric/treasury" "^0.3.0"
-    "@agoric/zoe" "^0.15.0"
-    "@babel/generator" "^7.6.4"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/cosmos" "^0.27.1"
+    "@agoric/import-bundle" "^0.2.32"
+    "@agoric/install-ses" "^0.5.29"
+    "@agoric/marshal" "^0.5.0"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/store" "^0.6.7"
+    "@agoric/swing-store" "^0.6.3"
+    "@agoric/swingset-vat" "^0.24.0"
+    "@agoric/vats" "^0.5.0"
+    "@agoric/xsnap" "^0.11.0"
     "@iarna/toml" "^2.2.3"
     "@opentelemetry/exporter-prometheus" "^0.16.0"
     "@opentelemetry/metrics" "^0.16.0"
-    agoric "^0.12.9"
+    agoric "^0.13.20"
     anylogger "^0.21.0"
-    chalk "^2.4.2"
     deterministic-json "^1.0.5"
-    esm "^3.2.25"
-    express "^4.17.1"
-    minimist "^1.2.0"
-    morgan "^1.9.1"
-    n-readlines "^1.0.0"
-    node-fetch "^2.6.0"
-    node-lmdb "^0.9.4"
-    polycrc "https://github.com/agoric-labs/node-polycrc"
-    rollup "^1.26.2"
-    rollup-plugin-node-resolve "^5.2.0"
-    temp "^0.9.1"
-    ws "^7.2.0"
+    import-meta-resolve "^1.1.1"
+    node-lmdb "^0.9.5"
+    tmp "^0.2.1"
 
-"@agoric/cosmos@^0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@agoric/cosmos/-/cosmos-0.25.0.tgz#7128919f193210296ae4bb51b9e15f6300df4383"
-  integrity sha512-+tX1g8kj+XSkJTDBiSpMn/Mdg7poSjZG1nwGG+8RPRkq3eArWsz/t1zevRoZJ2xC2Jj843UFHFm7XqVkeWYy2g==
+"@agoric/cosmos@^0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@agoric/cosmos/-/cosmos-0.27.1.tgz#80387f23288df4c5c6744197858d6b0091199297"
+  integrity sha512-mHZu5uzx67yR98w3eUkvUvxP2mOig+prdciI3OjybnpBv0Wae4gxaBgE7wV/I9dWt3y6EO43MmpNksjXEx8r/Q==
   dependencies:
     bindings "^1.2.1"
 
-"@agoric/dapp-svelte-wallet@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@agoric/dapp-svelte-wallet/-/dapp-svelte-wallet-0.9.0.tgz#d9a89ba6a7b2f42fb2bb94f4366538bdc5cb8d7d"
-  integrity sha512-YkYyy4wE0TOo7J5ZG8aHx7Nh7jBLNEKwljSQcMzTY+f1HHqUgxsUzm4PECSHaf2ZCWmzH5JUT1vfEtloEXu83w==
+"@agoric/deploy-script-support@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@agoric/deploy-script-support/-/deploy-script-support-0.6.0.tgz#e0b881d8923ee063467e3c82ce111d5307882911"
+  integrity sha512-xScILU2BaR9Hy3WjbwUY5RIHmLCoesYlBE0fnsNsFcbosjTc1Ry0zUWQXGEJO8Ji9lroaSpaQ7ooFexOzjs3Tg==
   dependencies:
-    "@agoric/babel-parser" "^7.6.4"
-    agoric "^0.12.9"
-    babel-eslint "^10.0.3"
-    eslint-plugin-eslint-comments "^3.1.2"
-
-"@agoric/deploy-script-support@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@agoric/deploy-script-support/-/deploy-script-support-0.2.2.tgz#df97aec550bc7999f59ab88cdf273b4102e54be1"
-  integrity sha512-AluiiiPAWv3xh+5xE8PMe6YtF7SMDA6eSjV7xS/WLg5ua83gzUJ1L+sZ4st2gxG7lJpDBKAkA9S+HNUrTbJlsQ==
-  dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/bundle-source" "^1.3.1"
-    "@agoric/cosmic-swingset" "^0.29.0"
-    "@agoric/ertp" "^0.10.4"
-    "@agoric/eventual-send" "^0.13.7"
-    "@agoric/import-manager" "^0.2.7"
-    "@agoric/marshal" "^0.4.4"
-    "@agoric/nat" "^4.0.0"
-    "@agoric/notifier" "^0.3.7"
-    "@agoric/promise-kit" "^0.2.6"
-    "@agoric/same-structure" "^0.1.6"
-    "@agoric/store" "^0.4.7"
-    "@agoric/zoe" "^0.15.0"
-
-"@agoric/ertp@*", "@agoric/ertp@^0.10.4":
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/@agoric/ertp/-/ertp-0.10.4.tgz#3d5da82c9e2a5791317be9f7d6a49b6c24ca1f0b"
-  integrity sha512-yxdCTkwHxEuF8E4Sx7Qq7sp1Mq2FafsuG8YfYjJrfIVhNahwxws8M7XDd0BgbwbDL0bvmmD3+e8JbSqmfa82LQ==
-  dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/eventual-send" "^0.13.7"
-    "@agoric/import-manager" "^0.2.7"
-    "@agoric/marshal" "^0.4.4"
-    "@agoric/nat" "^4.0.0"
-    "@agoric/notifier" "^0.3.7"
-    "@agoric/promise-kit" "^0.2.6"
-    "@agoric/same-structure" "^0.1.6"
-    "@agoric/store" "^0.4.7"
-
-"@agoric/ertp@^0.11.11":
-  version "0.11.11"
-  resolved "https://registry.yarnpkg.com/@agoric/ertp/-/ertp-0.11.11.tgz#39b3812615b275d6ffd79f5305c27e831dcb4b37"
-  integrity sha512-kUi2Slr0orBgR2X6DCk8c3wlVlD1ynV2vXIRJJQ4PDi9FU514+j2lp/Lg8Xt8eiYfV26xmXPYiPENbe+OaphVg==
-  dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@agoric/eventual-send" "^0.13.23"
-    "@agoric/marshal" "^0.4.20"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/bundle-source" "^2.0.1"
+    "@agoric/ertp" "^0.13.0"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/import-manager" "^0.2.32"
+    "@agoric/marshal" "^0.5.0"
     "@agoric/nat" "^4.1.0"
-    "@agoric/notifier" "^0.3.23"
-    "@agoric/promise-kit" "^0.2.21"
-    "@agoric/same-structure" "^0.1.21"
-    "@agoric/store" "^0.4.23"
+    "@agoric/notifier" "^0.3.32"
+    "@agoric/promise-kit" "^0.2.29"
+    "@agoric/same-structure" "^0.1.29"
+    "@agoric/store" "^0.6.7"
+    "@agoric/vats" "^0.5.0"
+    "@agoric/zoe" "^0.21.0"
 
-"@agoric/eventual-send@*", "@agoric/eventual-send@^0.13.6", "@agoric/eventual-send@^0.13.7":
-  version "0.13.7"
-  resolved "https://registry.yarnpkg.com/@agoric/eventual-send/-/eventual-send-0.13.7.tgz#6414ffa8b025a34c7074b03a63eb739698ad6c12"
-  integrity sha512-2R94fuM0PXMvZPOotKoYc7dM2PaR2AJ9ZQqnsj7glec32HC/rrm1tZDqBqdpx81oRmdQbsmceMTTlUtcrHoPEg==
-
-"@agoric/eventual-send@^0.13.23":
-  version "0.13.23"
-  resolved "https://registry.yarnpkg.com/@agoric/eventual-send/-/eventual-send-0.13.23.tgz#93d5a535e59af8ed43dfeb2398ddb470398bb5d2"
-  integrity sha512-+Ct1+rPrthfTULIZVsxSFJ6sbu0iWVytpmKhUQUELCnKyVANrDrH1OJkEREYuYjPCE1s5wMHW+GCsa3oqZh2WQ==
-
-"@agoric/import-bundle@^0.2.23":
-  version "0.2.23"
-  resolved "https://registry.yarnpkg.com/@agoric/import-bundle/-/import-bundle-0.2.23.tgz#d95f8206a443736cf7337cc74993b918f13ba1fa"
-  integrity sha512-MVutpscCNe3pLobBWQQ8NwKF7DTZK46/XCELkxQn6EX5/JInGNIIphf5K9mDm4PcyXQa5U+gZXmHhRIKoIV+og==
+"@agoric/ertp@*", "@agoric/ertp@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@agoric/ertp/-/ertp-0.13.0.tgz#ab31c6cdc00c0b63964dc3d209eb137db6ae0b8a"
+  integrity sha512-ehHKXvrPee6k4MoGE0eHIpwq46iBHxmJombmJ/L1b+ic233T77cM80h5BE0culwJlAZdPjVWjX3bgbbWDMNr+Q==
   dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@endo/base64" "^0.2.4"
-    "@endo/compartment-mapper" "^0.4.1"
-
-"@agoric/import-bundle@^0.2.7":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@agoric/import-bundle/-/import-bundle-0.2.7.tgz#d01d29d2f1a8639cb7c030837825d1a4834d5a38"
-  integrity sha512-qIlSPI++vXLmmmhp0CQKMOtLqUeD7UgUpp6dxrbfRbe3ovVKpHN9tY3BvGKODEbyv3vE/DgsmVL49/aZSMqA1g==
-  dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/compartment-mapper" "^0.2.3"
-    "@endo/base64" "^0.1.0"
-
-"@agoric/import-manager@^0.2.7":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@agoric/import-manager/-/import-manager-0.2.7.tgz#324429d0993be7dc5f4afb38e95042ae01a45f4b"
-  integrity sha512-TQ1mHepFxL9OfWW/KNCZmxQFczWQ41x+UNMJT5mfbtFQT0CcSrOyR437Wooy3+Bma4AsBwHZ6Yf427FUMS4Y4A==
-
-"@agoric/install-metering-and-ses@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@agoric/install-metering-and-ses/-/install-metering-and-ses-0.2.6.tgz#5b8adaac39e19d338b0f02009635e75a514b8e9a"
-  integrity sha512-uBBXhLiDZZtDuqnPggXMuD7JfwKWf2BiaRrxPhfHqUvjEUaEaJlEY72eeAxVzRLD5ZSsGEx9Tdo8GStQZ1Sk0w==
-  dependencies:
-    "@agoric/eventual-send" "^0.13.6"
-    "@agoric/install-ses" "^0.5.6"
-    "@agoric/tame-metering" "^1.3.6"
-
-"@agoric/install-ses@*", "@agoric/install-ses@^0.5.6":
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/@agoric/install-ses/-/install-ses-0.5.6.tgz#a3f66ded4459041ae700a5d192c9fe22ee77c71a"
-  integrity sha512-8cPIHEcOaOYUf4gOgYJGy/uxMtgm3g6fPeJ2iXyhDT48PJ9zHgflVLgJt7hBX3P7re3/0XUjViboAy+dH+U2/A==
-  dependencies:
-    "@agoric/eventual-send" "^0.13.6"
-    ses "^0.12.7"
-
-"@agoric/install-ses@^0.5.21":
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/@agoric/install-ses/-/install-ses-0.5.21.tgz#19cc528a0e3cece25c23c1756dbc030e255eca55"
-  integrity sha512-gAJMvAWenJGVM7LBkOe2F4YruVaGOAQTLN9proYjiVmlWAaZbMr8hNxw7WPUZJpBvLOKkmcGqf56z6A7L9OagQ==
-  dependencies:
-    "@agoric/eventual-send" "^0.13.23"
-    ses "^0.13.4"
-
-"@agoric/make-hardener@^0.1.2":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.1.3.tgz#807b0072bef95d935c3370d406d9dfeb719f69ee"
-  integrity sha512-rc9M2ErE/Zu822OLCnAltr957ZVTsBvVZ7KA2unqDpjo3q7PqZF2hWFB1xXD2Qkfwt5exQ3BjFbkj+NUaTg4gA==
-
-"@agoric/marshal@*", "@agoric/marshal@^0.4.20":
-  version "0.4.20"
-  resolved "https://registry.yarnpkg.com/@agoric/marshal/-/marshal-0.4.20.tgz#51832e69819c1a9876d5f03f2b98213d8197ba09"
-  integrity sha512-YLLhkIqP7FMNoazwhouSSkZXxkMGlmaW+xIFx0FcR87djsHkI7uhDXCno0Bi//ChAxDqqXiLa2aL7GSKUgsqQw==
-  dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@agoric/eventual-send" "^0.13.23"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/marshal" "^0.5.0"
     "@agoric/nat" "^4.1.0"
-    "@agoric/promise-kit" "^0.2.21"
+    "@agoric/notifier" "^0.3.32"
+    "@agoric/promise-kit" "^0.2.29"
+    "@agoric/same-structure" "^0.1.29"
+    "@agoric/store" "^0.6.7"
 
-"@agoric/marshal@^0.4.3", "@agoric/marshal@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@agoric/marshal/-/marshal-0.4.4.tgz#31475eaf96501ac8a9b18e08abb7135d34d25d8e"
-  integrity sha512-uTTYbK0GbS0YZJj1bcjwZDyFOWGmEO6c+1Zj3RWCvTHmAfKfvtjjcoed7HPi47dC7usqXTGRiS9niQhTyG9Law==
+"@agoric/eventual-send@*", "@agoric/eventual-send@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@agoric/eventual-send/-/eventual-send-0.14.0.tgz#72412cc5d84dcac78077f92a43d5bd58401e3938"
+  integrity sha512-3AqRLLftV+YVYtPyQ2JV/ulK8RRRrYJNyK1R34jNUGMnlfokTjIf5iEQO+YAUof5xycwlmyqd9BZd8BEDOq2sg==
+
+"@agoric/far@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@agoric/far/-/far-0.1.1.tgz#bca44464b7c1fc9a22f6b5a8dc0d1c7ea2fef3d9"
+  integrity sha512-kftomTuWJ+oiy3Ho+7VMrrwMCDQBPCcVay7w8Ei2WQX1t7J/fhqamnl8IF6rAd41Dy8becsXVE5yQ0UwmELDRg==
   dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/eventual-send" "^0.13.7"
-    "@agoric/nat" "^4.0.0"
-    "@agoric/promise-kit" "^0.2.6"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/marshal" "^0.5.0"
 
-"@agoric/nat@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-4.0.0.tgz#330dcde37fcf8882dbc5012a3b2c4c135eee4930"
-  integrity sha512-zlTe14g0PGfONO0+TdhLv8k4IZH040ojvBZuNrcQSV+l8HlFTZ/IKzI5HorlCVDDBU7riykAb/6MaTgMRbYp3w==
+"@agoric/governance@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@agoric/governance/-/governance-0.4.0.tgz#5fd882e8d6fbe941482023a64753fa7883088f8e"
+  integrity sha512-G9mza8p+jQWXSPKW0pFRy8AfEAUKiU8Dt1cQwjegrDDAoqzLApTsdLVxU9tbc62ly6tDRIDOUsfIG8JE1oV9UQ==
+  dependencies:
+    "@agoric/assert" "^0.3.15"
+    "@agoric/captp" "^1.10.7"
+    "@agoric/ertp" "^0.13.0"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/marshal" "^0.5.0"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "^0.3.32"
+    "@agoric/promise-kit" "^0.2.29"
+    "@agoric/same-structure" "^0.1.29"
+    "@agoric/store" "^0.6.7"
+    "@agoric/zoe" "^0.21.0"
+
+"@agoric/import-bundle@^0.2.32":
+  version "0.2.32"
+  resolved "https://registry.yarnpkg.com/@agoric/import-bundle/-/import-bundle-0.2.32.tgz#10ae8a3773400363a8f0dd8d41f407a5a34b4ca1"
+  integrity sha512-aUWWL/vyuDmc/FgGKDSiV0LitBFmTlRU4IVNalDT5ERNagFidVojioBPUNMCubgdNT1WNkYTUOUA/OT7hpniFQ==
+  dependencies:
+    "@agoric/assert" "^0.3.15"
+    "@endo/base64" "^0.2.8"
+    "@endo/compartment-mapper" "^0.5.3"
+
+"@agoric/import-manager@^0.2.32":
+  version "0.2.32"
+  resolved "https://registry.yarnpkg.com/@agoric/import-manager/-/import-manager-0.2.32.tgz#be3b83b24f81901ade4af6aa16409164c7d5e49b"
+  integrity sha512-6Gyn2b8jkF5FyORnA5iDSuakuYl8jRloKrwqWjH+4+NfWAz9aaWt2kqqU4R3V/F8oloHruT7nn9dr+9FcrMa9Q==
+
+"@agoric/install-ses@*", "@agoric/install-ses@^0.5.29":
+  version "0.5.29"
+  resolved "https://registry.yarnpkg.com/@agoric/install-ses/-/install-ses-0.5.29.tgz#605b599cc47c6a3f33a0f9bfeece3e6c04e7e8c4"
+  integrity sha512-l7feHQQyYz4YAakuf4KnAmGoDIVPXUncDwHckhMlvu5850I1sbBMjibuKuz4ypAf91FX7eK5flVolgWYA7V2eg==
+
+"@agoric/marshal@*", "@agoric/marshal@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@agoric/marshal/-/marshal-0.5.0.tgz#f3beb3d53b99c0198cd8df4b5cd97a4ba2c468c3"
+  integrity sha512-NAl7RMkElWJBtgFkD3aAkQRpGedatns2OWbBMgDXV2iVWSpxJPf1s1Ufcr5enJLKjpRlGzXGewCN4Q+BkWp1FA==
+  dependencies:
+    "@agoric/assert" "^0.3.15"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/promise-kit" "^0.2.29"
 
 "@agoric/nat@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-4.1.0.tgz#102794e033ffc183a20b0f86031a2e76d204b9f6"
   integrity sha512-2oMoh3DMn0Fx8HChPPiH8irBNdT/33ttxAZJohhd3nU3gyBRQ1u+eEoOQWfSkrE6M02iMkQM7GE9MzGmjQ6bHg==
 
-"@agoric/notifier@^0.3.23":
-  version "0.3.23"
-  resolved "https://registry.yarnpkg.com/@agoric/notifier/-/notifier-0.3.23.tgz#a6c67bf404cb58cd2be089ae950f9486d782acd4"
-  integrity sha512-aNGOXTt3hTbKUk8UqPicijX1O5huUst7IefMJuETgbJHsfU5alCuhayISEXScougbTyIQwpfUW3Cri3SsPdVSw==
+"@agoric/notifier@^0.3.32":
+  version "0.3.32"
+  resolved "https://registry.yarnpkg.com/@agoric/notifier/-/notifier-0.3.32.tgz#62be82f43564ec3ab986e6ea1c7d2021adbb5d51"
+  integrity sha512-Z/1Azmis9V7pxSlMBCuJE7fXA0zXLc30S0tkJShp9WpyX0wZduLh6eeBqF1HS1JwE793BawIY1nvRNvGpJkr8Q==
   dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@agoric/eventual-send" "^0.13.23"
-    "@agoric/marshal" "^0.4.20"
-    "@agoric/promise-kit" "^0.2.21"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/marshal" "^0.5.0"
+    "@agoric/promise-kit" "^0.2.29"
 
-"@agoric/notifier@^0.3.7":
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/@agoric/notifier/-/notifier-0.3.7.tgz#5bb8d1f0181422298bf04135f18b19f28612d696"
-  integrity sha512-NMoPxDNjRbBM8MACjGkl4XZ+sX9oTOvv6d0ir7514CJMorBHxjCBhFHZcU8ThOUjIqKKgX4USZRQXb4UF9EeyA==
+"@agoric/pegasus@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@agoric/pegasus/-/pegasus-0.5.0.tgz#159310605edb7dd5633fc594e22d317a36cf5c96"
+  integrity sha512-d8oQY4kXnqQkhHMoi4AbWw5Tv/6VWH05z0u+2MyQ0baI17k2T/0DF6N27qFjdkBDIgsYjL1FAkejF9M36J0XJA==
   dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/eventual-send" "^0.13.7"
-    "@agoric/marshal" "^0.4.4"
-    "@agoric/promise-kit" "^0.2.6"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/bundle-source" "^2.0.1"
+    "@agoric/captp" "^1.10.7"
+    "@agoric/deploy-script-support" "^0.6.0"
+    "@agoric/ertp" "^0.13.0"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/install-ses" "^0.5.29"
+    "@agoric/marshal" "^0.5.0"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "^0.3.32"
+    "@agoric/promise-kit" "^0.2.29"
+    "@agoric/store" "^0.6.7"
+    "@agoric/swingset-vat" "^0.24.0"
+    "@agoric/vats" "^0.5.0"
+    "@agoric/zoe" "^0.21.0"
 
-"@agoric/pegasus@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@agoric/pegasus/-/pegasus-0.2.0.tgz#19b1c88848c102341444b0975b76b7c2f5e37ac7"
-  integrity sha512-N1GVQEWxkPIKe/2xne41nmNnVhizMWu3puHQwRYk+TeK85/dTjXSAXe3lTa3rq3ZZB4Y91OimdiJEpfeiIAtmw==
+"@agoric/promise-kit@*", "@agoric/promise-kit@^0.2.29":
+  version "0.2.29"
+  resolved "https://registry.yarnpkg.com/@agoric/promise-kit/-/promise-kit-0.2.29.tgz#fcbbf68835808e613bf356b38ea21421eb309701"
+  integrity sha512-DjHYcXDfmw5Vq6WhhgLVtli43W+OhfqN6n9FwYl3q7jayuh34YI5WJznyZnMxT6esRBpPO+JMDXb96thgXS0KA==
   dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/bundle-source" "^1.3.1"
-    "@agoric/captp" "^1.7.6"
-    "@agoric/cosmic-swingset" "^0.29.0"
-    "@agoric/deploy-script-support" "^0.2.2"
-    "@agoric/ertp" "^0.10.4"
-    "@agoric/eventual-send" "^0.13.7"
-    "@agoric/marshal" "^0.4.4"
-    "@agoric/nat" "^4.0.0"
-    "@agoric/notifier" "^0.3.7"
-    "@agoric/promise-kit" "^0.2.6"
-    "@agoric/store" "^0.4.7"
-    "@agoric/swingset-vat" "^0.16.0"
-    "@agoric/zoe" "^0.15.0"
+    "@agoric/eventual-send" "^0.14.0"
 
-"@agoric/promise-kit@*", "@agoric/promise-kit@^0.2.21":
-  version "0.2.21"
-  resolved "https://registry.yarnpkg.com/@agoric/promise-kit/-/promise-kit-0.2.21.tgz#66aa16a020479c610608f169ae08eea9d018d62a"
-  integrity sha512-3v7FxmkH5qBkMjQ5Js99VJfKbi06ez5HaRTo/iX47x7i+rzyVB6f9wwVXnlPXWnbFyRxaOuiz1R4hqd6CHEDTA==
+"@agoric/recast@^0.20.6":
+  version "0.20.6"
+  resolved "https://registry.yarnpkg.com/@agoric/recast/-/recast-0.20.6.tgz#38f7130dc87d410a1eaa1d82de2b4528732c6228"
+  integrity sha512-pmgM/0g290/lGLmSfzR1/jh6Ij247yZJhJ8gw9180Vg/R7TcW3+pS4Vv9rlx2864ROeLC6GFlICEhFPjwprevw==
   dependencies:
-    "@agoric/eventual-send" "^0.13.23"
+    ast-types "0.14.2"
+    esprima "~4.0.0"
+    source-map "~0.6.1"
+    tslib "^2.0.1"
 
-"@agoric/promise-kit@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@agoric/promise-kit/-/promise-kit-0.2.6.tgz#e11ac8fbeb00c144941fbf03f53203d55a5ec8ff"
-  integrity sha512-6RCPgt5RpRq6/a9NgH/7xAR2GaHTiUn7K+PJuW1vBMPMhn56qxx2Mw5Ieol4+DZ6TIcC4WOBGtCwL6YTAF5DKg==
+"@agoric/same-structure@^0.1.29":
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/@agoric/same-structure/-/same-structure-0.1.29.tgz#1b2a86aadb93ba4ef0f0bc05f014198783e9854f"
+  integrity sha512-2tUNK3U7dfHM35pCfxE7FmaqV+d+TayXHtQDS3OPaLj7U72twslyOWk6IKyZZT93RmG2uUGNFxn8NFWWxh53hw==
   dependencies:
-    "@agoric/eventual-send" "^0.13.6"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/marshal" "^0.5.0"
 
-"@agoric/registrar@^0.2.7":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@agoric/registrar/-/registrar-0.2.7.tgz#2e15a6f566fd5054b3b5a3006e666f1b0831f32c"
-  integrity sha512-X31Qf0qkQdi3mduFlH5XM8ydedCACDps5p7PrlVzZ3XQDZkjbLdJ+jbjSA/yMVPCJqgoIzHhejgowyXpyc3+GA==
+"@agoric/sharing-service@^0.1.32":
+  version "0.1.32"
+  resolved "https://registry.yarnpkg.com/@agoric/sharing-service/-/sharing-service-0.1.32.tgz#3c93c1498d5591f382ab3af9013a8f3ba040c793"
+  integrity sha512-Pbj0wDXFO/VypeecOnV5CCu6mLOT78jVGc/c1Nh2BUej9hc6GAlKUWGvzqV+Qe723ekkfk34qNb3qgWPjPlBmw==
   dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/sparse-ints" "^0.1.6"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/marshal" "^0.5.0"
 
-"@agoric/same-structure@^0.1.21":
-  version "0.1.21"
-  resolved "https://registry.yarnpkg.com/@agoric/same-structure/-/same-structure-0.1.21.tgz#647afa5de3ac3c728afe27659e773d4d529079fd"
-  integrity sha512-vv038JuNpr918WOlvnKO6rOkWdA9rJvF+tqyWBi0BIim9TwGYCbMoWHtGTy3z14Rw9pRV/CtHKXvrdTZKuGx8g==
+"@agoric/sparse-ints@^0.1.24":
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/@agoric/sparse-ints/-/sparse-ints-0.1.24.tgz#d77fdb4abb3c9e978db3ced767987e2d4480332a"
+  integrity sha512-0PQOq2lUFtn9vft9DgW5r0DIxzlnahIe9CY6MBjs3V+JA7iTRX0OkqY3Ms7ozIMyQyDAtygUPI2M24o2TO8MXw==
+
+"@agoric/store@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@agoric/store/-/store-0.6.7.tgz#bec8de3dbad7daa2e7467bf2f832af1988820854"
+  integrity sha512-20D0GeCIs3/Gs+pSgkLKdNz1KmX8YwLuLIcJ6UyQNUgjgI4UNZkFSSbh13ty1wEHxXfXeKpgcKbRGpJ5btq3Zg==
   dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@agoric/marshal" "^0.4.20"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/marshal" "^0.5.0"
 
-"@agoric/same-structure@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@agoric/same-structure/-/same-structure-0.1.6.tgz#6a107c4f8dfcad70a705fe2d6f5668633907e2a9"
-  integrity sha512-KufeFIGNLh1CnqNktOoBsjMhlS30rv4XpR/h++mCQKQLS5HMTiKFebwykchLpyJVznZSeqsAUUml0kpvptTE0g==
+"@agoric/swing-store@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@agoric/swing-store/-/swing-store-0.6.3.tgz#6f9e6b3a43f27b8ff10f22c10a56a1cf9dd58dd9"
+  integrity sha512-tztlXpHXZPGqPczl2Ze7rrQ5c+kGSFIxUHc3t2xPdIWMrFVuKMHYaQOyvn5x2kQ2lFjq1KPQYWTVczE8x15TpA==
   dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/marshal" "^0.4.3"
-
-"@agoric/sharing-service@^0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@agoric/sharing-service/-/sharing-service-0.1.7.tgz#76fb2450c98ba61723e621859ed0246feacf6956"
-  integrity sha512-vKgfWHIXCidvDwW78ZKUM7cFq9gK9jKI16onGVZ0QadamjfHQ2hZGhQ3gCliPT1k+fCvGdlembnNbOcq5eSlYw==
-  dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/marshal" "^0.4.4"
-
-"@agoric/sparse-ints@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@agoric/sparse-ints/-/sparse-ints-0.1.6.tgz#9a58c0eb46691d92bb44516f5bb851923f020261"
-  integrity sha512-gABvfjUBakKIX3OW1maICgybBfuRbTJTQr4QQieHDVPgP1TtNuUEK9xgfDJAlyo0N4Kpaeb2XXB/L/XT9MguGw==
-
-"@agoric/spawner@^0.4.7":
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/@agoric/spawner/-/spawner-0.4.7.tgz#469dabc8647937cd74a9d3a3c0038970a750b8ed"
-  integrity sha512-542mbXybt6t7n0M2zI90urqwrbjZehg8i1kN8J6qIwJqfuyJVQLHdWCZCOnjJJurrxUZ1lIpA4Wd0AOYHffjLw==
-  dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/ertp" "^0.10.4"
-    "@agoric/eventual-send" "^0.13.7"
-    "@agoric/import-bundle" "^0.2.7"
-    "@agoric/marshal" "^0.4.4"
-    "@agoric/nat" "^4.0.0"
-    "@agoric/promise-kit" "^0.2.6"
-    "@agoric/same-structure" "^0.1.6"
-    "@agoric/store" "^0.4.7"
-    "@agoric/transform-metering" "^1.4.6"
-
-"@agoric/store@^0.4.23":
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/@agoric/store/-/store-0.4.23.tgz#2db7c85b1ba636a1d0277bd0207b0b522042e37c"
-  integrity sha512-CY9yr1yLnXFEJ8ukrYaPYxuN3asDuuV2vYbPaYCdbzXs7vv9mFkOj/c5c8xz/v3RfWYNRSOulH78bfh5uVN+yA==
-  dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@agoric/marshal" "^0.4.20"
-
-"@agoric/store@^0.4.7":
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/@agoric/store/-/store-0.4.7.tgz#d95fb1fee739d46b5c872c3591cd173900bcd56a"
-  integrity sha512-d1wSPGLLIc/N5V6ZIVCIZZDAEw2RJj/LQAEgzehIdQ5FabkdCfwbyANI7+dwCYDD+2nrlEFlVUo1Vt54Og423w==
-  dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/marshal" "^0.4.4"
-
-"@agoric/swing-store-lmdb@^0.4.6":
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/@agoric/swing-store-lmdb/-/swing-store-lmdb-0.4.6.tgz#69303f39a3e4bb920effb0b13c9f5f31c5e8e73e"
-  integrity sha512-/Hwkp/QRsaC9iTmW65Js2OaUMg1cISLG++23dPF62zrGX89VkdeY8sJN9Iq+gGjgBnOTt8aevfPj0/jqnfQeYQ==
-  dependencies:
-    node-lmdb "^0.9.4"
-
-"@agoric/swing-store-lmdb@^0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@agoric/swing-store-lmdb/-/swing-store-lmdb-0.5.7.tgz#82f7d8294ddaf89d6cdd4186dd62b97deafc56d8"
-  integrity sha512-YHFCKRigfAN/hYNQwIZ2Ln33b5pywkLuc6BsvErQY39mAoNxxLupwJTurYzd+CFuIsCYRFQIy1rhgfrFP/8rZw==
-  dependencies:
-    "@agoric/assert" "^0.3.7"
+    "@agoric/assert" "^0.3.15"
     better-sqlite3 "^7.4.1"
-    node-lmdb "^0.9.4"
-
-"@agoric/swing-store-simple@^0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@agoric/swing-store-simple/-/swing-store-simple-0.3.6.tgz#7aaa456c4b45c3abf68e18fd851dd11f5e416358"
-  integrity sha512-XSaqpowcIXRnJx87zO99G5q+L+Sdx+tyLkuc/Z3axf2kv9jSD1EdpmkyZ7RQqKhPbNDOl1dvSDolUe6uf2uxKw==
-  dependencies:
-    n-readlines "^1.0.0"
-
-"@agoric/swing-store-simple@^0.4.7":
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/@agoric/swing-store-simple/-/swing-store-simple-0.4.7.tgz#c4cf6067181ef640883a201f54acadd92769a12e"
-  integrity sha512-pG+6zungnAWLuWpbjBWJmddQ6UTVeNfnL5MpS7OGOxBzAqX1z5oiPR9ZIDCHiToDlUVZyAKxgjpZQHC560AuYA==
-  dependencies:
-    "@agoric/assert" "^0.3.7"
-    n-readlines "^1.0.0"
-
-"@agoric/swingset-vat@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@agoric/swingset-vat/-/swingset-vat-0.16.0.tgz#04dd5414e3fedf6c470434667c1a23140ea1c21f"
-  integrity sha512-ep6msQ6qe//lksnqB3B3V2ucg/0SkFtYyd4KYAjQ5mqc2TMoDXHci4ldvIF7YFCjzfX0zW+GJLerW1YG+hOM4Q==
-  dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/babel-parser" "^7.6.4"
-    "@agoric/bundle-source" "^1.3.1"
-    "@agoric/captp" "^1.7.6"
-    "@agoric/eventual-send" "^0.13.7"
-    "@agoric/import-bundle" "^0.2.7"
-    "@agoric/install-ses" "^0.5.6"
-    "@agoric/marshal" "^0.4.4"
-    "@agoric/nat" "^4.0.0"
-    "@agoric/notifier" "^0.3.7"
-    "@agoric/promise-kit" "^0.2.6"
-    "@agoric/store" "^0.4.7"
-    "@agoric/swing-store-simple" "^0.3.6"
-    "@agoric/tame-metering" "^1.3.6"
-    "@agoric/transform-eventual-send" "^1.4.6"
-    "@agoric/transform-metering" "^1.4.6"
-    "@agoric/xsnap" "^0.5.1"
-    "@babel/core" "^7.5.0"
-    "@babel/generator" "^7.6.4"
-    "@endo/base64" "^0.1.0"
-    "@types/tmp" "^0.2.0"
-    anylogger "^0.21.0"
-    esm "^3.2.5"
-    re2 "^1.10.5"
-    rollup "^1.23.1"
-    rollup-plugin-node-resolve "^5.2.0"
-    semver "^6.3.0"
-    ses "^0.12.7"
-    tmp "^0.2.1"
-    yargs "^14.2.0"
-
-"@agoric/swingset-vat@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@agoric/swingset-vat/-/swingset-vat-0.19.0.tgz#7b4873d2c93316db3bb07d3756def463607ecf90"
-  integrity sha512-dgfP0Q/rmPVbsF+5/H8GuX02qn3Pv8ypqssf93hNcoDv2YE3jHEO5TDrPPWX6C9o8vAHlyj/XFaIAdpM+9VGnw==
-  dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@agoric/babel-standalone" "^7.14.3"
-    "@agoric/bundle-source" "^1.4.5"
-    "@agoric/captp" "^1.8.0"
-    "@agoric/eventual-send" "^0.13.23"
-    "@agoric/import-bundle" "^0.2.23"
-    "@agoric/install-ses" "^0.5.21"
-    "@agoric/marshal" "^0.4.20"
-    "@agoric/nat" "^4.1.0"
-    "@agoric/notifier" "^0.3.23"
-    "@agoric/promise-kit" "^0.2.21"
-    "@agoric/store" "^0.4.23"
-    "@agoric/swing-store-lmdb" "^0.5.7"
-    "@agoric/swing-store-simple" "^0.4.7"
-    "@agoric/xsnap" "^0.6.10"
-    "@endo/base64" "^0.2.4"
-    "@types/tmp" "^0.2.0"
-    anylogger "^0.21.0"
-    esm agoric-labs/esm#Agoric-built
-    node-lmdb "^0.9.4"
-    re2 "^1.10.5"
-    semver "^6.3.0"
-    ses "^0.13.4"
+    node-lmdb "^0.9.5"
     tmp "^0.2.1"
 
-"@agoric/tame-metering@^1.3.6":
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/@agoric/tame-metering/-/tame-metering-1.3.6.tgz#860e6bf7de687fe5969daf5c4bcce2650c0e3029"
-  integrity sha512-Sw1aw4EMFwiS8I8sDFe7Wpn+1OJw43gsEQar9pT6dsrBTArgRB7X9A22GHHVH+KALw9CCgWCuJh2fZRol/oDTw==
+"@agoric/swingset-vat@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@agoric/swingset-vat/-/swingset-vat-0.24.0.tgz#5152f44b01ed5c7325b66dae9ff153106b7d1947"
+  integrity sha512-W46FT92rZYWEanWnewOAW3BLwai/qTET3VPrcEF0l4EehwlvutojlLjpi91aR2o4qQYY43XCvmvT5gHbYLHFgw==
   dependencies:
-    esm "^3.2.5"
-
-"@agoric/tame-metering@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@agoric/tame-metering/-/tame-metering-2.0.7.tgz#140b548a33c100bc917ec88812fcc91aed5b3936"
-  integrity sha512-ryx2YVHAOqfhlVydSyZYptp2g5fWO03qnkaJtLHiRBnYb32Vu2kJy0NPVMsF+rkvjlKfcWugV6TjHY/BQJ3LfQ==
-
-"@agoric/transform-eventual-send@^1.4.6":
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/@agoric/transform-eventual-send/-/transform-eventual-send-1.4.6.tgz#04f2dca657997d58f5222e67c1f2dce79cccd808"
-  integrity sha512-XICAgqUeitTJusQ2ULUlNh+EVWMDMULTAn+JZV7j0NgUQysqlHB1TaB6pNPJnIkJSLkOFWNomVNtNXZ1WAhzUQ==
-
-"@agoric/transform-metering@^1.4.20":
-  version "1.4.20"
-  resolved "https://registry.yarnpkg.com/@agoric/transform-metering/-/transform-metering-1.4.20.tgz#0a9eb24053c560e804daf4deef3344632bd3bbdd"
-  integrity sha512-RfQhp8n9o3tvLUIozMCrI8HsViklInpIIh3sjcgLEWVVhuv0+sSNnBkN8F9u7dDE3ViWOpvWXQFq45sCWK2/UA==
-  dependencies:
+    "@agoric/assert" "^0.3.15"
+    "@agoric/bundle-source" "^2.0.1"
+    "@agoric/captp" "^1.10.7"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/import-bundle" "^0.2.32"
+    "@agoric/install-ses" "^0.5.29"
+    "@agoric/marshal" "^0.5.0"
     "@agoric/nat" "^4.1.0"
-    "@agoric/tame-metering" "^2.0.7"
-    "@babel/generator" "^7.14.2"
-    "@babel/parser" "^7.14.2"
-    "@babel/traverse" "^7.14.2"
-    "@babel/types" "^7.14.2"
-    re2 "^1.10.5"
+    "@agoric/notifier" "^0.3.32"
+    "@agoric/promise-kit" "^0.2.29"
+    "@agoric/store" "^0.6.7"
+    "@agoric/swing-store" "^0.6.3"
+    "@agoric/xsnap" "^0.11.0"
+    "@endo/base64" "^0.2.8"
+    anylogger "^0.21.0"
+    import-meta-resolve "^1.1.1"
+    node-lmdb "^0.9.5"
+    semver "^6.3.0"
 
-"@agoric/transform-metering@^1.4.6":
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/@agoric/transform-metering/-/transform-metering-1.4.6.tgz#50e683855fd090ebc5c1816692b0d69c89a011a4"
-  integrity sha512-nxj3v/M7rL/a/pP0bxu5YAuVErVz5WS9PiEpzkBkok6Qd2mXOi+8njiaAAYifvSJNXQsLu2U4RTdf6BbTOzW7w==
+"@agoric/treasury@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@agoric/treasury/-/treasury-0.7.0.tgz#46a6a0b7df4a4f442aefd8842c2eba20683edafa"
+  integrity sha512-ONFQwM2F1ym779sp63vgJQXwo35gzrEHmxvWtrC4fuwdu3CT1SWtUPLiEynVK6si+Zu7oc6Z17zvOyV/TL2/RQ==
   dependencies:
-    "@agoric/nat" "^4.0.0"
-    "@agoric/tame-metering" "^1.3.6"
-    re2 "^1.10.5"
-
-"@agoric/transform-module@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@agoric/transform-module/-/transform-module-0.4.1.tgz#9fb152364faf372e1bda535cb4ef89717724f57c"
-  integrity sha512-4TJJHXeXAWu1FCA7yXCAZmhBNoGTB/BEAe2pv+J2X8W/mJTr9b395OkDCSRMpzvmSshLfBx6wT0D7dqWIWEC1w==
-
-"@agoric/treasury@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@agoric/treasury/-/treasury-0.3.0.tgz#3508a80b9d508e61b6192f276165ee21c6d2c923"
-  integrity sha512-RXmR8UD4bO0FO/YFTpz4Q+LwylLNsgvFV59ZcJ+pN5MNJYaBfP4ntCZeSw1jeCAH69OGpnuzQO9tLDyIXxcQXQ==
-  dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/bundle-source" "^1.3.1"
-    "@agoric/captp" "^1.7.6"
-    "@agoric/deploy-script-support" "^0.2.2"
-    "@agoric/ertp" "^0.10.4"
-    "@agoric/eventual-send" "^0.13.7"
-    "@agoric/marshal" "^0.4.4"
-    "@agoric/nat" "^4.0.0"
-    "@agoric/notifier" "^0.3.7"
-    "@agoric/promise-kit" "^0.2.6"
-    "@agoric/store" "^0.4.7"
-    "@agoric/swingset-vat" "^0.16.0"
-    "@agoric/zoe" "^0.15.0"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/bundle-source" "^2.0.1"
+    "@agoric/captp" "^1.10.7"
+    "@agoric/deploy-script-support" "^0.6.0"
+    "@agoric/ertp" "^0.13.0"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/governance" "^0.4.0"
+    "@agoric/marshal" "^0.5.0"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "^0.3.32"
+    "@agoric/promise-kit" "^0.2.29"
+    "@agoric/same-structure" "^0.1.29"
+    "@agoric/store" "^0.6.7"
+    "@agoric/swingset-vat" "^0.24.0"
+    "@agoric/zoe" "^0.21.0"
 
 "@agoric/ui-components@*":
-  version "0.2.18"
-  resolved "https://registry.yarnpkg.com/@agoric/ui-components/-/ui-components-0.2.18.tgz#5bca681cedf2ccc034dad088603a8dde6e758037"
-  integrity sha512-CNPWZ9RYybp/8JIaCYhRwAZc7heMxul2UeniM3pnHpvZ+oYHfsy+5fDtO18JLDyzS8rJ9//pCnlM8b9r+GXs9g==
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@agoric/ui-components/-/ui-components-0.2.27.tgz#0f3ce15618967d645d273a85413b843be9cee2f8"
+  integrity sha512-YOGnq8bueLT37MclOxzjL9JczJ4wVByUz6NrbiRDt43pU6i33b3bHU4sfuKH1F0zbg/JHMKE+HQSlHjypcN0Xg==
   dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@agoric/ertp" "^0.11.11"
-    "@agoric/eventual-send" "^0.13.23"
-    "@agoric/install-ses" "^0.5.21"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/ertp" "^0.13.0"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/install-ses" "^0.5.29"
     "@agoric/nat" "^4.1.0"
-    "@agoric/zoe" "^0.17.6"
+    "@agoric/zoe" "^0.21.0"
     clsx "^1.1.1"
 
-"@agoric/xsnap@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@agoric/xsnap/-/xsnap-0.5.1.tgz#fb903a80a3edb9d4962d44fbb3c7270fe670f161"
-  integrity sha512-t6TxMgcTmOtnfJh3MzRr0dSgWB9Tmn+vn+SRZSa8BkeqQgqyaTs3aia3SncppR/ShtairRQj/hmnvGr92aEgxg==
+"@agoric/vats@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@agoric/vats/-/vats-0.5.0.tgz#0d8d43aba10743d4edca86cc71b3275aab3667e5"
+  integrity sha512-RrRh4B1B7TsrBO6ikaPqrEbskrATxCP6ReNekj2iJTcaIoANsVKWC+qQWBqcb4xTVQul48gPQF8ODCfGbEtKxw==
   dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/bundle-source" "^1.3.1"
-    "@agoric/eventual-send" "^0.13.6"
-    "@agoric/install-ses" "^0.5.6"
-    esm "^3.2.5"
-    glob "^7.1.6"
-    ses "^0.12.7"
-
-"@agoric/xsnap@^0.6.10":
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/@agoric/xsnap/-/xsnap-0.6.10.tgz#acff6b343dd2d0db28f94662449fa458e89eb76a"
-  integrity sha512-0dJqOzqaQkCcnK3B6nZ4s71Fuz7PtNShAgwsqAt4078sUtbyi0Pq6m0pw5XGJrGpopMvZmPIrXG4fhsn4kz34w==
-  dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@agoric/babel-standalone" "^7.14.3"
-    "@agoric/bundle-source" "^1.4.5"
-    "@agoric/eventual-send" "^0.13.23"
-    "@agoric/install-ses" "^0.5.21"
-    esm agoric-labs/esm#Agoric-built
-    glob "^7.1.6"
-    ses "^0.13.4"
-
-"@agoric/zoe@*", "@agoric/zoe@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@agoric/zoe/-/zoe-0.15.0.tgz#422744634f1a2e63e35b97732beba3404f38c7ac"
-  integrity sha512-yD6nTjng/SMNcEw42grewe+4hwdMzO3O+JqeesXPXxkdUKA8uot4uYw8vd6tu9tQ8ik5nG6UQya9vR/kvmzhEw==
-  dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/bundle-source" "^1.3.1"
-    "@agoric/ertp" "^0.10.4"
-    "@agoric/eventual-send" "^0.13.7"
-    "@agoric/import-bundle" "^0.2.7"
-    "@agoric/marshal" "^0.4.4"
-    "@agoric/nat" "^4.0.0"
-    "@agoric/notifier" "^0.3.7"
-    "@agoric/promise-kit" "^0.2.6"
-    "@agoric/same-structure" "^0.1.6"
-    "@agoric/store" "^0.4.7"
-    "@agoric/swingset-vat" "^0.16.0"
-    "@agoric/transform-metering" "^1.4.6"
-
-"@agoric/zoe@^0.17.6":
-  version "0.17.6"
-  resolved "https://registry.yarnpkg.com/@agoric/zoe/-/zoe-0.17.6.tgz#45ce7002854ff48dee1a1566efedb75eace63379"
-  integrity sha512-pPVjObYh+A2l8Ih2MofLFyDY3eOZPFa6eSWfXE0EM7m/QufL58AcWL1wVXJcKXyMCaPD2UydXnQk/kmMvtLdvA==
-  dependencies:
-    "@agoric/assert" "^0.3.7"
-    "@agoric/bundle-source" "^1.4.5"
-    "@agoric/ertp" "^0.11.11"
-    "@agoric/eventual-send" "^0.13.23"
-    "@agoric/import-bundle" "^0.2.23"
-    "@agoric/marshal" "^0.4.20"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/ertp" "^0.13.0"
+    "@agoric/far" "^0.1.1"
+    "@agoric/import-bundle" "^0.2.32"
+    "@agoric/install-ses" "^0.5.29"
     "@agoric/nat" "^4.1.0"
-    "@agoric/notifier" "^0.3.23"
-    "@agoric/promise-kit" "^0.2.21"
-    "@agoric/same-structure" "^0.1.21"
-    "@agoric/store" "^0.4.23"
-    "@agoric/swingset-vat" "^0.19.0"
-    "@agoric/transform-metering" "^1.4.20"
+    "@agoric/notifier" "^0.3.32"
+    "@agoric/pegasus" "^0.5.0"
+    "@agoric/promise-kit" "^0.2.29"
+    "@agoric/same-structure" "^0.1.29"
+    "@agoric/sharing-service" "^0.1.32"
+    "@agoric/sparse-ints" "^0.1.24"
+    "@agoric/store" "^0.6.7"
+    "@agoric/swingset-vat" "^0.24.0"
+    "@agoric/treasury" "^0.7.0"
+    "@agoric/wallet-backend" "^0.10.6"
+    "@agoric/zoe" "^0.21.0"
+
+"@agoric/wallet-backend@^0.10.6":
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/@agoric/wallet-backend/-/wallet-backend-0.10.6.tgz#7b36462510471abd27bfc8079843fd85953a136b"
+  integrity sha512-l8W90ke/K3+sy+LPrNR7svRfrUj6szapOzkiy5BP3OVnKwK5de/ciyciuJzAEPGHxAuKRaAsL9AP5gcmJJ8HNQ==
+  dependencies:
+    "@agoric/assert" "^0.3.15"
+    "@agoric/ertp" "^0.13.0"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/marshal" "^0.5.0"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "^0.3.32"
+    "@agoric/promise-kit" "^0.2.29"
+    "@agoric/store" "^0.6.7"
+    "@agoric/zoe" "^0.21.0"
+    import-meta-resolve "^1.1.1"
+
+"@agoric/xsnap@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@agoric/xsnap/-/xsnap-0.11.0.tgz#6b07b3d6ce2a3e3ed4cd4e00af1b957d614077d5"
+  integrity sha512-EY9CPz+rg8Wq/+mY/buQO51VIdfxuG+X6yZVKmUq2XG/l4LRxLR/Vy7dE42MXyihLT57cAKh7iZN0Ae22qlbkw==
+  dependencies:
+    "@agoric/assert" "^0.3.15"
+    "@agoric/babel-standalone" "^7.14.3"
+    "@agoric/bundle-source" "^2.0.1"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/install-ses" "^0.5.29"
+    "@endo/netstring" "^0.2.8"
+    glob "^7.1.6"
+
+"@agoric/zoe@*", "@agoric/zoe@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@agoric/zoe/-/zoe-0.21.0.tgz#0e15c5b85a82707ac1b33cc09ab7ceb4d18ca6ef"
+  integrity sha512-FXDzkFaJZHegEs7lB8jiijpmk4WZs9Ztkc3MNJpUL5hIjTa1R5exhaO0TxrGocF8Ra2GmsAD00F0YiCWCw2h2g==
+  dependencies:
+    "@agoric/assert" "^0.3.15"
+    "@agoric/bundle-source" "^2.0.1"
+    "@agoric/ertp" "^0.13.0"
+    "@agoric/eventual-send" "^0.14.0"
+    "@agoric/governance" "^0.4.0"
+    "@agoric/import-bundle" "^0.2.32"
+    "@agoric/marshal" "^0.5.0"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "^0.3.32"
+    "@agoric/promise-kit" "^0.2.29"
+    "@agoric/same-structure" "^0.1.29"
+    "@agoric/store" "^0.6.7"
+    "@agoric/swingset-vat" "^0.24.0"
 
 "@apidevtools/json-schema-ref-parser@^9.0.3":
   version "9.0.9"
@@ -694,7 +411,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13":
+"@babel/code-frame@^7.0.0":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
   integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
@@ -708,40 +425,12 @@
   dependencies:
     "@babel/highlight" "^7.14.5"
 
-"@babel/compat-data@^7.13.12":
-  version "7.13.15"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.15.tgz#7e8eea42d0b64fda2b375b22d06c605222e848f4"
-  integrity sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==
-
-"@babel/core@^7.5.0":
-  version "7.13.15"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.15.tgz#a6d40917df027487b54312202a06812c4f7792d0"
-  integrity sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==
+"@babel/code-frame@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
+  integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
   dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.13.9"
-    "@babel/helper-compilation-targets" "^7.13.13"
-    "@babel/helper-module-transforms" "^7.13.14"
-    "@babel/helpers" "^7.13.10"
-    "@babel/parser" "^7.13.15"
-    "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.13.15"
-    "@babel/types" "^7.13.14"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.1.2"
-    semver "^6.3.0"
-    source-map "^0.5.0"
-
-"@babel/generator@^7.13.9", "@babel/generator@^7.6.4":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39"
-  integrity sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
-  dependencies:
-    "@babel/types" "^7.13.0"
-    jsesc "^2.5.1"
-    source-map "^0.5.0"
+    "@babel/highlight" "^7.16.0"
 
 "@babel/generator@^7.14.2", "@babel/generator@^7.14.5":
   version "7.14.5"
@@ -752,24 +441,14 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-compilation-targets@^7.13.13":
-  version "7.13.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz#2b2972a0926474853f41e4adbc69338f520600e5"
-  integrity sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==
+"@babel/generator@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.0.tgz#d40f3d1d5075e62d3500bccb67f3daa8a95265b2"
+  integrity sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==
   dependencies:
-    "@babel/compat-data" "^7.13.12"
-    "@babel/helper-validator-option" "^7.12.17"
-    browserslist "^4.14.5"
-    semver "^6.3.0"
-
-"@babel/helper-function-name@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a"
-  integrity sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
-  dependencies:
-    "@babel/helper-get-function-arity" "^7.12.13"
-    "@babel/template" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.16.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
 
 "@babel/helper-function-name@^7.14.5":
   version "7.14.5"
@@ -780,12 +459,14 @@
     "@babel/template" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/helper-get-function-arity@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz#bc63451d403a3b3082b97e1d8b3fe5bd4091e583"
-  integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
+"@babel/helper-function-name@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz#b7dd0797d00bbfee4f07e9c4ea5b0e30c8bb1481"
+  integrity sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/helper-get-function-arity" "^7.16.0"
+    "@babel/template" "^7.16.0"
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-get-function-arity@^7.14.5":
   version "7.14.5"
@@ -794,6 +475,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-get-function-arity@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz#0088c7486b29a9cb5d948b1a1de46db66e089cfa"
+  integrity sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-hoist-variables@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz#e0dd27c33a78e577d7c8884916a3e7ef1f7c7f8d"
@@ -801,64 +489,12 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-member-expression-to-functions@^7.13.12":
-  version "7.13.12"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz#dfe368f26d426a07299d8d6513821768216e6d72"
-  integrity sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==
+"@babel/helper-hoist-variables@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz#4c9023c2f1def7e28ff46fc1dbcd36a39beaa81a"
+  integrity sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==
   dependencies:
-    "@babel/types" "^7.13.12"
-
-"@babel/helper-module-imports@^7.13.12":
-  version "7.13.12"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
-  integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
-  dependencies:
-    "@babel/types" "^7.13.12"
-
-"@babel/helper-module-transforms@^7.13.14":
-  version "7.13.14"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz#e600652ba48ccb1641775413cb32cfa4e8b495ef"
-  integrity sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==
-  dependencies:
-    "@babel/helper-module-imports" "^7.13.12"
-    "@babel/helper-replace-supers" "^7.13.12"
-    "@babel/helper-simple-access" "^7.13.12"
-    "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/helper-validator-identifier" "^7.12.11"
-    "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.13.13"
-    "@babel/types" "^7.13.14"
-
-"@babel/helper-optimise-call-expression@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz#5c02d171b4c8615b1e7163f888c1c81c30a2aaea"
-  integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
-  dependencies:
-    "@babel/types" "^7.12.13"
-
-"@babel/helper-replace-supers@^7.13.12":
-  version "7.13.12"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz#6442f4c1ad912502481a564a7386de0c77ff3804"
-  integrity sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==
-  dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.13.12"
-    "@babel/helper-optimise-call-expression" "^7.12.13"
-    "@babel/traverse" "^7.13.0"
-    "@babel/types" "^7.13.12"
-
-"@babel/helper-simple-access@^7.13.12":
-  version "7.13.12"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz#dd6c538afb61819d205a012c31792a39c7a5eaf6"
-  integrity sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
-  dependencies:
-    "@babel/types" "^7.13.12"
-
-"@babel/helper-split-export-declaration@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
-  integrity sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
-  dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-split-export-declaration@^7.14.5":
   version "7.14.5"
@@ -866,6 +502,13 @@
   integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-split-export-declaration@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz#29672f43663e936df370aaeb22beddb3baec7438"
+  integrity sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==
+  dependencies:
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-validator-identifier@^7.12.11":
   version "7.12.11"
@@ -877,19 +520,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
   integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
 
-"@babel/helper-validator-option@^7.12.17":
-  version "7.12.17"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
-  integrity sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
-
-"@babel/helpers@^7.13.10":
-  version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.13.10.tgz#fd8e2ba7488533cdeac45cc158e9ebca5e3c7df8"
-  integrity sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==
-  dependencies:
-    "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.13.0"
-    "@babel/types" "^7.13.0"
+"@babel/helper-validator-identifier@^7.15.7":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
+  integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
   version "7.13.10"
@@ -909,15 +543,24 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.12.13", "@babel/parser@^7.13.15", "@babel/parser@^7.7.0":
-  version "7.13.15"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.15.tgz#8e66775fb523599acb6a289e12929fa5ab0954d8"
-  integrity sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==
+"@babel/highlight@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.0.tgz#6ceb32b2ca4b8f5f361fb7fd821e3fddf4a1725a"
+  integrity sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.15.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
 
 "@babel/parser@^7.14.2", "@babel/parser@^7.14.5", "@babel/parser@^7.14.7":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.7.tgz#6099720c8839ca865a2637e6c85852ead0bdb595"
   integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
+
+"@babel/parser@^7.16.0", "@babel/parser@^7.16.3":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
+  integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
 
 "@babel/runtime-corejs3@^7.10.2":
   version "7.13.10"
@@ -934,15 +577,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
-  integrity sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
-  dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/parser" "^7.12.13"
-    "@babel/types" "^7.12.13"
-
 "@babel/template@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
@@ -952,17 +586,27 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/traverse@^7.13.0", "@babel/traverse@^7.13.13", "@babel/traverse@^7.13.15", "@babel/traverse@^7.7.0", "@babel/traverse@^7.8.3":
-  version "7.13.15"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.15.tgz#c38bf7679334ddd4028e8e1f7b3aa5019f0dada7"
-  integrity sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==
+"@babel/template@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.0.tgz#d16a35ebf4cd74e202083356fab21dd89363ddd6"
+  integrity sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==
   dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.13.9"
-    "@babel/helper-function-name" "^7.12.13"
-    "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/parser" "^7.13.15"
-    "@babel/types" "^7.13.14"
+    "@babel/code-frame" "^7.16.0"
+    "@babel/parser" "^7.16.0"
+    "@babel/types" "^7.16.0"
+
+"@babel/traverse@^7.10.4":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.3.tgz#f63e8a938cc1b780f66d9ed3c54f532ca2d14787"
+  integrity sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==
+  dependencies:
+    "@babel/code-frame" "^7.16.0"
+    "@babel/generator" "^7.16.0"
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/helper-hoist-variables" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
+    "@babel/parser" "^7.16.3"
+    "@babel/types" "^7.16.0"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -981,16 +625,15 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.14", "@babel/types@^7.7.0":
-  version "7.13.14"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.14.tgz#c35a4abb15c7cd45a2746d78ab328e362cbace0d"
-  integrity sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==
+"@babel/types@^7.10.4", "@babel/types@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
+  integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
-    lodash "^4.17.19"
+    "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.14.2", "@babel/types@^7.14.5":
+"@babel/types@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
   integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
@@ -1019,30 +662,25 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@endo/base64@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.1.0.tgz#d321d5b36f16648f0b0b05d96f93501d6a461501"
-  integrity sha512-wVBsKkVV3t3mGT1XVoQAYkBpnum/OEJ0kBka3s7PSQnAne0aFmi1P9IIWyHzsoIgdai7ONTpGSgBZIk6X9dOrw==
+"@endo/base64@^0.2.8":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.2.12.tgz#691b7d333baccfb94004b6756975a1d34f899f52"
+  integrity sha512-VAsePQkgp9tsl9ntzz+dngb02OXBxL7muqBWmSlrP5sKB5NnG0fZX0PpcYlS26OjrlJZ1eEu3M5rSBoqLuHAow==
 
-"@endo/base64@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.2.4.tgz#5a00054c5a687d541edcb1c8841c90b51eb005cc"
-  integrity sha512-2cdvf29iftIuEZ4eGBZm064uaUHmp3ZIllLw2FA6wEfTLkgdT9cHczlIhUTD8t3ih620mj5I0VnUF11bA5nNmA==
+"@endo/cjs-module-analyzer@^0.2.11":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@endo/cjs-module-analyzer/-/cjs-module-analyzer-0.2.12.tgz#c7ae783d06c9d4ebbb96bf954e0c54ffa439d64f"
+  integrity sha512-hEED2OPSAP9l6Fj8Tr/7dHRxo5MyZKsvpVuYuoxdjKkcjRF9XuB2J+bVuAaQ4DnlQlrwHHliahGXsF5MB9o8gw==
 
-"@endo/cjs-module-analyzer@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@endo/cjs-module-analyzer/-/cjs-module-analyzer-0.2.4.tgz#78f2d698230e895e19ad25fd5bf69adadc77e0f1"
-  integrity sha512-XvSkS8FjIE3JRSeljlxwdvzl8QfRqRbSEHNbBvp2nVWgd1MiliXpLw3MdbgNjWTtndcD9EDn6KgPgPYg5NeHSQ==
-
-"@endo/compartment-mapper@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@endo/compartment-mapper/-/compartment-mapper-0.4.1.tgz#d4a76b09dbc1dd6d1c6f8accc0b84dea310a5ce1"
-  integrity sha512-9KAGBx15wzDOPFZ/E2k99gLfnwHk5bp7ZP6f9Torl3wl++9xWUqp4bDRLIIKoRRfucfKETI7RdxE8+oJ0AH+PA==
+"@endo/compartment-mapper@^0.5.3":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@endo/compartment-mapper/-/compartment-mapper-0.5.6.tgz#1c2a9e91c062a24a856e725e7d36a3ee5c46b73c"
+  integrity sha512-IaO5uZt54+WFW7m+xLxJUijEWpEbzIxJU+EVFWef8kLrmc1u1lVKIc2NxsNjmK5YZi7aaVu36m05WTNdnAhImw==
   dependencies:
-    "@endo/cjs-module-analyzer" "^0.2.4"
-    "@endo/static-module-record" "^0.5.4"
-    "@endo/zip" "^0.2.4"
-    ses "^0.13.4"
+    "@endo/cjs-module-analyzer" "^0.2.11"
+    "@endo/static-module-record" "^0.6.6"
+    "@endo/zip" "^0.2.11"
+    ses "^0.15.1"
 
 "@endo/eslint-config@^0.3.9":
   version "0.3.11"
@@ -1058,17 +696,25 @@
   dependencies:
     requireindex "~1.1.0"
 
-"@endo/static-module-record@^0.5.4":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@endo/static-module-record/-/static-module-record-0.5.4.tgz#80718e067f027a912aeeabc73c60e1e2b2854cd1"
-  integrity sha512-fJx5Nk36H+j+JjG82YK+bPuJnJ8TQ4INBkb+ddqQTWlnho9ijFPMnrhO7Zw6T0rqWy0URhyx4uNP193U4Bp55w==
+"@endo/netstring@^0.2.8":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@endo/netstring/-/netstring-0.2.12.tgz#a60b59f3d89c87dc537fe8d2df7e0100467ed9c9"
+  integrity sha512-Rb7wXV6/LsgEbFpnAhoZD2tVxHxBrUiMJKE4agtNZd5BF1NwWje0RKQt1cjSiTip7BHpmnwB1cdryBll1GYlwQ==
+
+"@endo/static-module-record@^0.6.6":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@endo/static-module-record/-/static-module-record-0.6.7.tgz#5b19a8fabe713ff3ca0db16c3c0b18cf75b90a17"
+  integrity sha512-0koDmwnpExIRQAVrSxmBfFsj+6kkxXxonrU9Umm9uBMIm2OyUzRGSIo7lfZkD4Qb/tKphrJSkCTD9l6lHILVYw==
   dependencies:
     "@agoric/babel-standalone" "^7.14.3"
+    "@agoric/recast" "^0.20.6"
+    "@babel/traverse" "^7.10.4"
+    "@babel/types" "^7.10.4"
 
-"@endo/zip@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@endo/zip/-/zip-0.2.4.tgz#2d8cecf7a8adb5fff1b8474046750dfa382fedbd"
-  integrity sha512-g2DZL/SW0lWl6U0ISijyRitGDnhdbgV0uphEo/y9M7k6abs+O8QekEL39XJ4qOfQXSkgRZIrVlJjQzd8Fj4tKQ==
+"@endo/zip@^0.2.11":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@endo/zip/-/zip-0.2.12.tgz#613e7d11460f118b2bf9e93d1c587fb0e86d7714"
+  integrity sha512-aMd2jzG2eIQAhvMSuerKm3Ulo6319hNsKmX9MhSAlaoRt0IddD+qeJpcwR2mEyfaW5mWQUg2djdr+8/YKopOKw==
 
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
@@ -1824,17 +1470,6 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
-"@rollup/plugin-commonjs@~11.0.2":
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-11.0.2.tgz#837cc6950752327cb90177b608f0928a4e60b582"
-  integrity sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
-  dependencies:
-    "@rollup/pluginutils" "^3.0.0"
-    estree-walker "^1.0.1"
-    is-reference "^1.1.2"
-    magic-string "^0.25.2"
-    resolve "^1.11.0"
-
 "@rollup/plugin-node-resolve@^13.0.0":
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz#352f07e430ff377809ec8ec8a6fd636547162dc4"
@@ -1847,18 +1482,7 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
-"@rollup/plugin-node-resolve@^7.1.1":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
-  integrity sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==
-  dependencies:
-    "@rollup/pluginutils" "^3.0.8"
-    "@types/resolve" "0.0.8"
-    builtin-modules "^3.1.0"
-    is-module "^1.0.0"
-    resolve "^1.14.2"
-
-"@rollup/pluginutils@^3.0.0", "@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
@@ -2046,13 +1670,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/resolve@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
-  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
@@ -2067,11 +1684,6 @@
   dependencies:
     "@types/mime" "^1"
     "@types/node" "*"
-
-"@types/tmp@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
-  integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
 
 "@types/yargs-parser@^20.2.1":
   version "20.2.1"
@@ -2160,7 +1772,7 @@ acorn-walk@^8.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.0.2.tgz#d4632bfc63fd93d0f15fd05ea0e984ffd3f5a8c3"
   integrity sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==
 
-acorn@^7.1.0, acorn@^7.4.0:
+acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -2199,23 +1811,25 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-agoric@*, agoric@^0.12.9:
-  version "0.12.9"
-  resolved "https://registry.yarnpkg.com/agoric/-/agoric-0.12.9.tgz#e487dee59879acdeaf91360f14d88f07fd84e7c1"
-  integrity sha512-HbLo6Mt3PtGYIhZQmeKOi6q8fOh1mZlK5uN8eWbp2ZtCW0DBQalG7yOO8cLEk/RCU63L0LWoACbKzE1qyEMvtA==
+agoric@*, agoric@^0.13.20:
+  version "0.13.20"
+  resolved "https://registry.yarnpkg.com/agoric/-/agoric-0.13.20.tgz#e91c2064aebf9f9acfea22873baecfbaa8e5e16a"
+  integrity sha512-wplocwYsWK0ZGj/6bmM828Dn0hV6Gq/TDrDLV0dIEZrmiTN8NhhHXPxnThenU+PilrX89LXIE47jZhclVK2r1w==
   dependencies:
-    "@agoric/assert" "^0.2.6"
-    "@agoric/bundle-source" "^1.3.1"
-    "@agoric/captp" "^1.7.6"
-    "@agoric/install-ses" "^0.5.6"
-    "@agoric/promise-kit" "^0.2.6"
-    "@agoric/swing-store-simple" "^0.3.6"
+    "@agoric/access-token" "^0.4.16"
+    "@agoric/assert" "^0.3.15"
+    "@agoric/bundle-source" "^2.0.1"
+    "@agoric/captp" "^1.10.7"
+    "@agoric/install-ses" "^0.5.29"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/promise-kit" "^0.2.29"
+    "@endo/compartment-mapper" "^0.5.3"
     "@iarna/toml" "^2.2.3"
     anylogger "^0.21.0"
     chalk "^2.4.2"
     commander "^5.0.0"
     deterministic-json "^1.0.5"
-    esm "^3.2.25"
+    esm agoric-labs/esm#Agoric-built
     inquirer "^6.3.1"
     opener "^1.5.2"
     ws "^7.2.0"
@@ -2282,7 +1896,7 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -2467,6 +2081,13 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
+ast-types@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
+  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+  dependencies:
+    tslib "^2.0.1"
+
 ast-types@^0.13.2:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
@@ -2589,18 +2210,6 @@ axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
-
-babel-eslint@^10.0.3:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
-  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.7.0"
-    "@babel/traverse" "^7.7.0"
-    "@babel/types" "^7.7.0"
-    eslint-visitor-keys "^1.0.0"
-    resolve "^1.12.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -2753,17 +2362,6 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browserslist@^4.14.5:
-  version "4.16.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.4.tgz#7ebf913487f40caf4637b892b268069951c35d58"
-  integrity sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==
-  dependencies:
-    caniuse-lite "^1.0.30001208"
-    colorette "^1.2.2"
-    electron-to-chromium "^1.3.712"
-    escalade "^3.1.1"
-    node-releases "^1.1.71"
-
 buffer-crc32@^0.2.1, buffer-crc32@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -2801,6 +2399,13 @@ builtin-modules@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
   integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
+
+builtins@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-4.0.0.tgz#a8345420de82068fdc4d6559d0456403a8fb1905"
+  integrity sha512-qC0E2Dxgou1IHhvJSLwGDSTvokbRovU5zZFuDY6oY8Y2lF3nGt5Ad8YZK7GMtqzY84Wu7pXTPeHQeHcXSXsRhw==
+  dependencies:
+    semver "^7.0.0"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -2884,7 +2489,7 @@ callsites@^3.0.0, callsites@^3.1.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camelcase@^5.0.0, camelcase@^5.3.1:
+camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -2893,11 +2498,6 @@ camelcase@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
-
-caniuse-lite@^1.0.30001208:
-  version "1.0.30001208"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz#a999014a35cebd4f98c405930a057a0d75352eb9"
-  integrity sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==
 
 cardinal@^2.1.1:
   version "2.1.1"
@@ -3088,15 +2688,6 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
-cliui@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
-  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
-  dependencies:
-    string-width "^3.1.0"
-    strip-ansi "^5.2.0"
-    wrap-ansi "^5.1.0"
-
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -3174,11 +2765,6 @@ color@3.0.x:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
-
-colorette@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
-  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
 colors@1.0.3:
   version "1.0.3"
@@ -3519,11 +3105,6 @@ debug@^3.1.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
-
 decompress-response@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
@@ -3726,11 +3307,6 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-
-electron-to-chromium@^1.3.712:
-  version "1.3.714"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.714.tgz#dabe0b67bd9463bcef5d25fe141daf8de7f93ea3"
-  integrity sha512-/xC2dSRZTzpPuKF/v+YZSYSkS0ZzktGrqou/ldu3MovPdEuLBzU/QUfEAc1as/M/KMbM5HZFQDs7/edNmSOpNA==
 
 emittery@^0.8.0:
   version "0.8.1"
@@ -3956,14 +3532,6 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-eslint-comments@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
-  integrity sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==
-  dependencies:
-    escape-string-regexp "^1.0.5"
-    ignore "^5.0.5"
-
 eslint-plugin-import@^2.22.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
@@ -4035,7 +3603,7 @@ eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -4133,7 +3701,7 @@ eslint@^7.23.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@^3.2.25, esm@^3.2.5, esm@agoric-labs/esm#Agoric-built:
+esm@agoric-labs/esm#Agoric-built:
   version "3.2.25"
   resolved "https://codeload.github.com/agoric-labs/esm/tar.gz/3603726ad4636b2f865f463188fcaade6375638e"
 
@@ -4174,11 +3742,6 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
-
-estree-walker@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
-  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
 estree-walker@^1.0.1:
   version "1.0.1"
@@ -4795,12 +4358,7 @@ gcs-resumable-upload@^3.3.0:
     pumpify "^2.0.0"
     stream-events "^1.0.4"
 
-gensync@^1.0.0-beta.2:
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
-  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
-
-get-caller-file@^2.0.1, get-caller-file@^2.0.5:
+get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -5025,7 +4583,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -5225,7 +4783,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.5, ignore@^5.1.4:
+ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -5255,6 +4813,13 @@ import-local@^3.0.2:
   dependencies:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
+
+import-meta-resolve@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-1.1.1.tgz#244fd542fd1fae73550d4f8b3cde3bba1d7b2b18"
+  integrity sha512-JiTuIvVyPaUg11eTrNDx5bgQ/yMKMZffc7YSjvQeSMXy58DO2SQ8BtAf3xteZvmzvjYh14wnqNjL8XVeDy2o9A==
+  dependencies:
+    builtins "^4.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -5540,7 +5105,7 @@ is-promise@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
-is-reference@^1.1.2, is-reference@^1.2.1:
+is-reference@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
   integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
@@ -5788,13 +5353,6 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
-
-json5@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -6252,7 +5810,7 @@ lru-queue@^0.1.0:
   dependencies:
     es5-ext "~0.10.2"
 
-magic-string@^0.25.2, magic-string@^0.25.7:
+magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -6520,7 +6078,7 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@^0.5.5:
+"mkdirp@>=0.5 0", mkdirp@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -6532,7 +6090,7 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-morgan@^1.10.0, morgan@^1.8.2, morgan@^1.9.1:
+morgan@^1.10.0, morgan@^1.8.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
   integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
@@ -6637,7 +6195,7 @@ node-emoji@^1.4.1:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@2.6.1, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.3.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -6651,22 +6209,6 @@ node-gyp-build@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
-
-node-gyp@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
-  integrity sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
-  dependencies:
-    env-paths "^2.2.0"
-    glob "^7.1.4"
-    graceful-fs "^4.2.3"
-    nopt "^5.0.0"
-    npmlog "^4.1.2"
-    request "^2.88.2"
-    rimraf "^3.0.2"
-    semver "^7.3.2"
-    tar "^6.0.2"
-    which "^2.0.2"
 
 node-gyp@^8.0.0:
   version "8.2.0"
@@ -6684,18 +6226,13 @@ node-gyp@^8.0.0:
     tar "^6.1.2"
     which "^2.0.2"
 
-node-lmdb@^0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/node-lmdb/-/node-lmdb-0.9.4.tgz#cde77d23445dc0528348ca0c8c39f552711939f8"
-  integrity sha512-tDpOdHLnEGEA4YqYg+oBYvQxRqeW3LoGFllZYNvUckZTc2kiqbz+JuNPuP4Cpw4xZI6i3dZb8opAFz2JMgs1Rg==
+node-lmdb@^0.9.5:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/node-lmdb/-/node-lmdb-0.9.6.tgz#b7bab03f8cf154a5df90f3a861239adb65ff3dbe"
+  integrity sha512-zpYvuTWoyGY/G9/0kLZyJlEnnvm4U1t7r1q1akX4vvwviuxGAysW9hN77YwbijvWN7cIC1GRp3ptMkJaUxXKHw==
   dependencies:
     nan "^2.14.1"
     node-gyp-build "^4.2.3"
-
-node-releases@^1.1.71:
-  version "1.1.71"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
-  integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -7193,10 +6730,6 @@ plur@^4.0.0:
   dependencies:
     irregular-plurals "^3.2.0"
 
-"polycrc@https://github.com/agoric-labs/node-polycrc":
-  version "1.0.1-agoric"
-  resolved "https://github.com/agoric-labs/node-polycrc#f396a902c5ba663cb91b6c8c13ec0afe792108d0"
-
 portfinder@^1.0.23:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -7454,15 +6987,6 @@ rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-re2@^1.10.5:
-  version "1.15.9"
-  resolved "https://registry.yarnpkg.com/re2/-/re2-1.15.9.tgz#9ed16171edcb0bc4f0e239bf55229ff3f26acbe3"
-  integrity sha512-AXWEhpMTBdC+3oqbjdU07dk0pBCvxh5vbOMLERL6Y8FYBSGn4vXlLe8cYszn64Yy7H8keVMrgPzoSvOd4mePpg==
-  dependencies:
-    install-artifact-from-github "^1.2.0"
-    nan "^2.14.2"
-    node-gyp "^7.1.2"
-
 re2@^1.15.8:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/re2/-/re2-1.16.0.tgz#f311eb4865b1296123800ea8e013cec8dab25590"
@@ -7650,11 +7174,6 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-require-main-filename@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
-  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
 requireindex@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
@@ -7677,7 +7196,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0:
+resolve@^1.10.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.19.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -7744,40 +7263,6 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
-
-rimraf@~2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rollup-plugin-node-resolve@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
-  integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
-  dependencies:
-    "@types/resolve" "0.0.8"
-    builtin-modules "^3.1.0"
-    is-module "^1.0.0"
-    resolve "^1.11.1"
-    rollup-pluginutils "^2.8.1"
-
-rollup-pluginutils@^2.8.1:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
-  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  dependencies:
-    estree-walker "^0.6.1"
-
-rollup@^1.23.1, rollup@^1.26.2, rollup@^1.32.0:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
 
 rollup@^2.47.0:
   version "2.52.3"
@@ -7918,26 +7403,12 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-ses@^0.12.6, ses@^0.12.7:
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/ses/-/ses-0.12.7.tgz#b795b76a8672fc12659c363dd777e06878394638"
-  integrity sha512-o6eTkzKNqfEtmNfA3j2F6xdL6W/f+HwtXiRWF7ebx4seQBn+3AnFnEIxQTvxShGTGvFH6sDl78YiJeT9N7e9UA==
-  dependencies:
-    "@agoric/babel-standalone" "^7.9.5"
-    "@agoric/make-hardener" "^0.1.2"
-    "@agoric/transform-module" "^0.4.1"
+ses@^0.15.1:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-0.15.2.tgz#d0739438cf0fe07f50f58d32e61036470095d6c2"
+  integrity sha512-g+eZO1YrFSAo8lDqoS3ibiF8zLRBjfTG6d4o0gq6HIWdcA6ejlbCM1K+6R8VZ/Krfr31xs+Gb8v7BqiuxRK4gA==
 
-ses@^0.13.4:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/ses/-/ses-0.13.4.tgz#d547202ccb180c4a161e52007a9edff51d5fa9fd"
-  integrity sha512-7pgHZF4i6tuMAhD6GeNgA8fxfgzeQ5queyRFnKfKPM6nvCEKd8JP3ityQ04rVspTzkzu9R0b2I4nb05ukblQDA==
-
-ses@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/ses/-/ses-0.14.0.tgz#d71a5ccac8e9054155c7e63a52325e924edd3b41"
-  integrity sha512-LQPb6IS19K12Osvndmu7lHoJVuYyxPPBAUSZlcVeOmHF4LMzjT8vIVoMYLyk4LHvmt6wBbrJph9JkIiD1+femQ==
-
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -8210,7 +7681,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^3.0.0, string-width@^3.1.0:
+string-width@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
   integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
@@ -8277,7 +7748,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -8489,14 +7960,6 @@ temp-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
   integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
-
-temp@^0.9.1:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.4.tgz#cd20a8580cb63635d0e4e9d4bd989d44286e7620"
-  integrity sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==
-  dependencies:
-    mkdirp "^0.5.1"
-    rimraf "~2.6.2"
 
 term-size@^2.1.0:
   version "2.2.1"
@@ -8962,11 +8425,6 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
-which-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
-  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-
 which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -9023,15 +8481,6 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-wrap-ansi@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
-  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
-  dependencies:
-    ansi-styles "^3.2.0"
-    string-width "^3.0.0"
-    strip-ansi "^5.0.0"
-
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -9086,11 +8535,6 @@ xtend@~4.0.0:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-y18n@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
-  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
-
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -9116,14 +8560,6 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@^15.0.1:
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
-  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^20.2.2:
   version "20.2.7"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
@@ -9133,23 +8569,6 @@ yargs-parser@^20.2.7:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
-yargs@^14.2.0:
-  version "14.2.3"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
-  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
-  dependencies:
-    cliui "^5.0.0"
-    decamelize "^1.2.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^15.0.1"
 
 yargs@^16.1.1, yargs@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
This PR updates the runner with a grab bag of fixes I did while making the stats generation more robust, and working on moving the provisioning check of the client for a testnet chain to the setup phase.

Checking earlier allows the testnet loadgen to pause before starting and wait until the client is provisioned, instead of requiring action after the start, which may be a while when catching up to an existing chain. I originally started adding the ability to auto provision a client for a local testnet (based on the keys and the same logic as a local-chain), but reverted course and moved that functionality into a separate script used by the integration test (see https://github.com/Agoric/agoric-sdk/pull/4256).

List of various fixes:
- Update to node 16 and Debian bullseye (with fallback to node 14 for older incompatible SDKs)
- Handle some older SDK versions which output lockdown sniffing to stdout instead of stderr
- Rewrote the config argv parsing logic, to make it behave slightly more sanely
- Fixed some deadlock issues, e.g. adding some timeouts on task ready (see #40) or slog streams not closing properly
- Capture client storage and slog file (should help track some transient seg faults in the solo)
- Automatically capture the state of the client and chain if an error occurs (see #39)
- Background the compression of the state directories after snapshotting them (overlayfs supports CoW). Closes #39 
- Avoid resetting the whole `agoric-servers` project in `local-chain` tests. Removes loadgen project `git` dependency.
- Elide long lines from the chain or solo output (improves github actions perf, see https://github.com/Agoric/agoric-sdk/pull/4113)

Stack on top of other compatibility fixes (#37).

As always, best reviewed commit-by-commit.