### PR TITLE
Add p95 to stats summaries

### DIFF
--- a/runner/bin/regen-perf.js
+++ b/runner/bin/regen-perf.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/* global process */
+
+import '../lib/sdk/install-ses.js';
+
+import { promisify } from 'util';
+import { pipeline as pipelineCallback } from 'stream';
+import BufferLineTransform from '../lib/helpers/buffer-line-transform.js';
+import { getBlocksSummaries, getCyclesSummaries } from '../lib/stats/stages.js';
+import {
+  getLiveBlocksSummary,
+  getCyclesSummary,
+  getTotalBlockCount,
+} from '../lib/stats/run.js';
+
+const pipeline = promisify(pipelineCallback);
+
+const { stdout, stdin } = process;
+
+async function* linesToEvent(lines) {
+  for await (const line of lines) {
+    yield JSON.parse(line.toString('utf8'));
+  }
+}
+
+async function* processEvent(events) {
+  for await (const event of events) {
+    if (event.type === 'perf-finish') {
+      /** @type {import('../lib/stats/types').RunStats} */
+      const stats = event.stats;
+
+      const stages = Object.fromEntries(
+        Object.entries(stats.stages).map(([idx, stage]) => {
+          const { blocks, cycles, endedAt } = stage;
+
+          // Currently if the stage fails, no summary is generated
+          if (endedAt === undefined) {
+            return [idx, stage];
+          }
+
+          const blockValues = Object.values(blocks);
+          const cycleValues = Object.values(cycles);
+
+          const blocksSummaries = blockValues.length
+            ? getBlocksSummaries(blockValues)
+            : undefined;
+          const cyclesSummaries = cycleValues.length
+            ? getCyclesSummaries(cycleValues)
+            : undefined;
+
+          return [idx, { ...stage, blocksSummaries, cyclesSummaries }];
+        }),
+      );
+
+      const cyclesSummary = getCyclesSummary(stages);
+      const liveBlocksSummary = getLiveBlocksSummary(stages);
+      const totalBlockCount = getTotalBlockCount(stages);
+
+      yield {
+        ...event,
+        stats: {
+          ...stats,
+          stages,
+          cyclesSummary,
+          liveBlocksSummary,
+          totalBlockCount,
+        },
+      };
+    } else {
+      yield event;
+    }
+  }
+}
+
+async function* eventToLine(events) {
+  for await (const event of events) {
+    yield `${JSON.stringify(event)}\n`;
+  }
+}
+
+await pipeline(
+  stdin,
+  new BufferLineTransform(),
+  linesToEvent,
+  processEvent,
+  eventToLine,
+  stdout,
+);

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -729,8 +729,9 @@ const main = async (progName, rawArgs, powers) => {
           tasks.push(stageReady);
         }
         stats.recordStart(timeSource.getTime());
-        await sequential(...tasks)((stop) => stop);
-        stats.recordEnd(timeSource.getTime());
+        await sequential(...tasks)((stop) => stop).finally(() =>
+          stats.recordEnd(timeSource.getTime()),
+        );
       },
       async (...stageError) =>
         aggregateTryFinally(

--- a/runner/lib/stats/blocks.js
+++ b/runner/lib/stats/blocks.js
@@ -90,6 +90,7 @@ export const makeBlockStatsSummary = ({
   items,
   mins,
   maxes,
+  p95s,
 }) =>
   blockCount
     ? {
@@ -115,6 +116,19 @@ export const makeBlockStatsSummary = ({
         ),
         avgProcessingPercentage: percentageRounder(
           averages.processingPercentage / 100,
+        ),
+        p95Lag: timeRounder(p95s.lag),
+        p95BlockDuration: timeRounder(p95s.blockDuration),
+        p95ChainBlockDuration: timeRounder(p95s.chainBlockDuration),
+        p95IdleTime: timeRounder(p95s.idleTime),
+        p95CosmosTime: timeRounder(p95s.cosmosTime),
+        p95SwingsetTime: timeRounder(p95s.swingsetTime),
+        p95ProcessingTime: timeRounder(p95s.processingTime),
+        p95Deliveries: timeRounder(p95s.deliveries),
+        p95Computrons: timeRounder(p95s.computrons),
+        p95SwingsetPercentage: percentageRounder(p95s.swingsetPercentage / 100),
+        p95ProcessingPercentage: percentageRounder(
+          p95s.processingPercentage / 100,
         ),
       }
     : undefined;

--- a/runner/lib/stats/blocks.js
+++ b/runner/lib/stats/blocks.js
@@ -79,7 +79,7 @@ const rawBlockStatsInit = {
  */
 
 /**
- * @param {import('./helpers.js').Sums<BlockStatsSumKeys>} sums
+ * @param {import('./helpers.js').Summary<BlockStatsSumKeys>} summary
  * @returns {import('./types.js').BlockStatsSummary | undefined}
  */
 export const makeBlockStatsSummary = ({

--- a/runner/lib/stats/cycles.js
+++ b/runner/lib/stats/cycles.js
@@ -38,13 +38,19 @@ const rawCycleStatsInit = {
  * @param {import('./helpers.js').Summary<CycleStatsSumKeys>} sums
  * @returns {import('./types.js').CycleStatsSummary | undefined}
  */
-export const makeCycleStatsSummary = ({ weights: cycleCount, averages }) =>
+export const makeCycleStatsSummary = ({
+  weights: cycleCount,
+  averages,
+  p95s,
+}) =>
   cycleCount
     ? {
         cycleCount,
         cycleSuccessRate: percentageRounder(averages.success),
         avgBlockCount: rounder(averages.blockCount),
         avgDuration: rounder(averages.duration),
+        p95BlockCount: rounder(p95s.blockCount),
+        p95Duration: rounder(p95s.duration),
       }
     : undefined;
 

--- a/runner/lib/stats/cycles.js
+++ b/runner/lib/stats/cycles.js
@@ -35,7 +35,7 @@ const rawCycleStatsInit = {
 /** @typedef {'success' | 'blockCount' | 'duration'} CycleStatsSumKeys */
 
 /**
- * @param {import('./helpers.js').Sums<CycleStatsSumKeys>} sums
+ * @param {import('./helpers.js').Summary<CycleStatsSumKeys>} sums
  * @returns {import('./types.js').CycleStatsSummary | undefined}
  */
 export const makeCycleStatsSummary = ({ weights: cycleCount, averages }) =>

--- a/runner/lib/stats/helpers.d.ts
+++ b/runner/lib/stats/helpers.d.ts
@@ -95,6 +95,7 @@ export type Summary<K extends string> = {
   readonly totals: SumRecord<K>; // weighted
   readonly counts: SumRecord<K>; // weighted
   readonly averages: SumRecord<K>; // weighted
+  readonly p95s: SumRecord<K>;
 };
 
 type SummaryRecord = { readonly [P in string]: number | undefined };

--- a/runner/lib/stats/helpers.d.ts
+++ b/runner/lib/stats/helpers.d.ts
@@ -86,7 +86,7 @@ type SumRecord<K extends string> = {
   readonly [P in K]: number;
 };
 
-export type Sums<K extends string> = {
+export type Summary<K extends string> = {
   readonly values: number;
   readonly weights: number;
   readonly items: SumRecord<K>;
@@ -97,11 +97,14 @@ export type Sums<K extends string> = {
   readonly averages: SumRecord<K>; // weighted
 };
 
-type SummableRecord = { readonly [P in string]: number | undefined };
+type SummaryRecord = { readonly [P in string]: number | undefined };
+export type SummarizeData<T extends SummaryRecord> = ReadonlyArray<{
+  values: T;
+  weight?: number;
+}>;
 
-interface Summer<T extends SummableRecord> {
-  add(value: T, weight?: 1 | number): void;
-  getSums(): Sums<keyof T>;
-}
+export declare function summarize<T extends SummaryRecord>(
+  data: SummarizeData<T>,
+): Summary<keyof T>;
 
-export declare function makeSummer<T extends SummableRecord>(): Summer<T>;
+export declare function notUndefined<T>(x: T | undefined): x is T;

--- a/runner/lib/stats/helpers.js
+++ b/runner/lib/stats/helpers.js
@@ -163,6 +163,7 @@ export const summarize = (data) => {
   const totals = /** @type {Record<string, number>} */ ({});
   const counts = /** @type {Record<string, number>} */ ({});
   const averages = /** @type {Record<string, number>} */ ({});
+  const p95s = /** @type {Record<string, number>} */ ({});
 
   for (const key of keys) {
     const sortedData = /** @type {Array<{values: Record<string, number>, weight?: number | undefined}>} */ (data.filter(
@@ -179,6 +180,21 @@ export const summarize = (data) => {
       counts[key] += weight;
     }
     averages[key] = totals[key] / counts[key];
+
+    if (
+      sortedData.length > 1 &&
+      sortedData.every(({ weight = 1 }) => weight === 1)
+    ) {
+      const rank = (95 * (sortedData.length - 1)) / 100;
+      const rankIndex = Math.floor(rank);
+      const basePercentile = sortedData[rankIndex].values[key];
+      const nextPercentile = sortedData[rankIndex + 1].values[key];
+      p95s[key] =
+        basePercentile +
+        (rankIndex - rankIndex) * (nextPercentile - basePercentile);
+    } else {
+      p95s[key] = NaN;
+    }
   }
 
   return harden({
@@ -190,5 +206,6 @@ export const summarize = (data) => {
     totals,
     counts,
     averages,
+    p95s,
   });
 };

--- a/runner/lib/stats/types.d.ts
+++ b/runner/lib/stats/types.d.ts
@@ -64,6 +64,17 @@ export type BlockStatsSummary = {
   readonly avgProcessingPercentage: number;
   readonly avgDeliveries: number;
   readonly avgComputrons: number;
+  readonly p95Lag: number;
+  readonly p95BlockDuration: number;
+  readonly p95ChainBlockDuration: number;
+  readonly p95IdleTime: number;
+  readonly p95CosmosTime: number;
+  readonly p95SwingsetTime: number;
+  readonly p95ProcessingTime: number;
+  readonly p95SwingsetPercentage: number;
+  readonly p95ProcessingPercentage: number;
+  readonly p95Deliveries: number;
+  readonly p95Computrons: number;
 };
 
 export interface CycleStatsInitData {
@@ -89,6 +100,8 @@ export type CycleStatsSummary = {
   readonly cycleCount: number;
   readonly avgBlockCount: number;
   readonly avgDuration: number;
+  readonly p95BlockCount: number | undefined;
+  readonly p95Duration: number | undefined;
   readonly cycleSuccessRate: number;
 };
 


### PR DESCRIPTION
As requested by @Tartuffo, this change refactors the stats summary generation and adds p95 percentiles to the values for which we generated averages.

I've also added a script which parses a `perf.jsonl` stream and rewrites the stats, regenerating the summaries. This helped me verify that the new summary logic didn't result in any real changes (just a few differences due to rounding).

```sh
for i in manual-*
do 
  echo $i
  diff \
    <(tail -q -n 1 $i/perf.jsonl | jq '.stats') \
    <(cat $i/perf.jsonl | ../runner/bin/regen-perf.js | tail -q -n 1 | jq '.stats')
done
```

I also fixed a bug where the stage stats summaries were not generated for a failing stage.

Related to: https://github.com/Agoric/testnet-load-generator/pull/36/commits/5d4034af7bee15c9d9698fec868ed499464b49d1 in https://github.com/Agoric/testnet-load-generator/pull/36