### PR TITLE
Compatibility with older SDK without solo slog

### DIFF
--- a/runner/lib/tasks/local-chain.js
+++ b/runner/lib/tasks/local-chain.js
@@ -386,7 +386,7 @@ export const makeTasks = ({
     const clientEnv = Object.create(process.env);
     clientEnv.SOLO_SLOGFILE = slogFifo.path;
 
-    const soloCp = printerSpawn(sdkBinaries.agSolo, ['start'], {
+    const soloCp = printerSpawn(sdkBinaries.agSolo, ['start', '--verbose'], {
       stdio: ['ignore', 'pipe', 'pipe'],
       cwd: clientStateDir,
       env: clientEnv,

--- a/runner/lib/tasks/local-chain.js
+++ b/runner/lib/tasks/local-chain.js
@@ -379,7 +379,9 @@ export const makeTasks = ({
     const slogFifo = await makeFIFO('client.slog');
     const slogReady = fsStreamReady(slogFifo);
     const slogLines = new BufferLineTransform();
-    const slogPipeResult = pipeline(slogFifo, slogLines);
+    const slogPipeResult = slogReady.then(() =>
+      slogLines.writableEnded ? undefined : pipeline(slogFifo, slogLines),
+    );
 
     const clientEnv = Object.create(process.env);
     clientEnv.SOLO_SLOGFILE = slogFifo.path;
@@ -429,7 +431,14 @@ export const makeTasks = ({
       clientDone,
     ]).then(() => {});
 
-    const ready = PromiseAllOrErrors([walletReady, slogReady]).then(() => {});
+    walletReady
+      .then(() =>
+        Promise.race([
+          slogReady,
+          Promise.reject(new Error('Slog not supported')),
+        ]),
+      )
+      .catch((err) => console.warn(err.message || err));
 
     return tryTimeout(
       timeout * 1000,
@@ -451,7 +460,7 @@ export const makeTasks = ({
         return harden({
           stop,
           done,
-          ready,
+          ready: walletReady,
           slogLines: cleanAsyncIterable(slogLines),
           storageLocation: clientStateDir,
           processInfo,

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -474,7 +474,7 @@ ${chainName} chain does not yet know of address ${soloAddr}
     const clientEnv = Object.create(process.env);
     clientEnv.SOLO_SLOGFILE = slogFifo.path;
 
-    const soloCp = printerSpawn(sdkBinaries.agSolo, ['start'], {
+    const soloCp = printerSpawn(sdkBinaries.agSolo, ['start', '--verbose'], {
       stdio: ['ignore', 'pipe', 'pipe'],
       cwd: clientStateDir,
       env: clientEnv,

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -467,7 +467,9 @@ ${chainName} chain does not yet know of address ${soloAddr}
     const slogFifo = await makeFIFO('client.slog');
     const slogReady = fsStreamReady(slogFifo);
     const slogLines = new BufferLineTransform();
-    const slogPipeResult = pipeline(slogFifo, slogLines);
+    const slogPipeResult = slogReady.then(() =>
+      slogLines.writableEnded ? undefined : pipeline(slogFifo, slogLines),
+    );
 
     const clientEnv = Object.create(process.env);
     clientEnv.SOLO_SLOGFILE = slogFifo.path;
@@ -517,7 +519,14 @@ ${chainName} chain does not yet know of address ${soloAddr}
       clientDone,
     ]).then(() => {});
 
-    const ready = PromiseAllOrErrors([walletReady, slogReady]).then(() => {});
+    walletReady
+      .then(() =>
+        Promise.race([
+          slogReady,
+          Promise.reject(new Error('Slog not supported')),
+        ]),
+      )
+      .catch((err) => console.warn(err.message || err));
 
     return tryTimeout(
       timeout * 1000,
@@ -539,7 +548,7 @@ ${chainName} chain does not yet know of address ${soloAddr}
         return harden({
           stop,
           done,
-          ready,
+          ready: walletReady,
           slogLines: cleanAsyncIterable(slogLines),
           storageLocation: clientStateDir,
           processInfo,


### PR DESCRIPTION
https://github.com/Agoric/testnet-load-generator/pull/44/commits/778b4e8cd66bb5aa268f5a5abc7059516742983f introduced the feature of saving the slog file of the ag-solo. However generating a slog file was only introduced in the SDK by https://github.com/Agoric/agoric-sdk/pull/3611, so solos from older SDK would never open the slog FIFO, and the solo would have been considered as never fully started, ultimately timing out and failing.

This change makes the solo slog optional, and conditionally pipes the streams to avoid failures.