### PR TITLE
Add CI integration job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,77 @@
+name: Integration test with agoric-sdk
+
+on:
+  push:
+    branches: [main] # $default-branch
+  pull_request:
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-18.04 # trusty
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: testnet-load-generator
+
+      - name: Get the appropriate agoric-sdk branch
+        id: get-sdk-branch
+        uses: actions/github-script@0.9.0
+        with:
+          result-encoding: string
+          script: |
+            let branch = 'master';
+            if (context.payload.pull_request) {
+              const { body } = context.payload.pull_request;
+              const regex = /.*\#agoric-sdk-branch:\s+(\S+)/;
+              const result = regex.exec(body);
+              if (result) {
+                branch = result[1];
+              }
+            }
+            console.log(branch);
+            return branch;
+
+      - name: Checkout agoric-sdk
+        uses: actions/checkout@v2
+        with:
+          repository: Agoric/agoric-sdk
+          submodules: 'true'
+          path: agoric-sdk
+          ref: ${{steps.get-sdk-branch.outputs.result}}
+
+      - name: set GOPATH
+        run: echo GOPATH="$HOME/go" >> $GITHUB_ENV
+        shell: bash
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: cache Go modules
+        uses: actions/cache@v2
+        id: go-cache
+        with:
+          path: ${{ env.GOPATH }}/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Start loadgen
+        working-directory: testnet-load-generator
+        env:
+          SDK_SRC: ${{ github.workspace }}/agoric-sdk
+        run: |
+          ./start.sh --no-stage.save-storage --no-reset \
+            --stages=3 --stage.duration=4

--- a/start.sh
+++ b/start.sh
@@ -45,7 +45,9 @@ export PATH="$AGORIC_BIN_DIR:$PATH"
 
 if [ ! -f "${OUTPUT_DIR}/.nvmrc" ] ; then
     SDK_NODE16_REVISION=475d7ff1eb2371aa9e0c0dc7a50644089db351f6
-    if ! git -C "${SDK_SRC}" merge-base --is-ancestor $SDK_NODE16_REVISION $SDK_FULL_REVISION ; then
+    if git -C "${SDK_SRC}" cat-file -e $SDK_NODE16_REVISION^{commit} && \
+      ! git -C "${SDK_SRC}" merge-base --is-ancestor $SDK_NODE16_REVISION $SDK_FULL_REVISION
+    then
         echo "lts/fermium" > "${OUTPUT_DIR}/.nvmrc"
     fi
     if [ -n "$NVM_RC_VERSION" ]; then 


### PR DESCRIPTION
This PR adds an integration test of the loadgen runner with the latest version of the `agoric-sdk`. While it uses a `local-chain` instead of multinode chain like the integration test in the `agoric-sdk` repo (see https://github.com/Agoric/agoric-sdk/pull/4256), besides setup most of the loadgen logic is shared, so it should be enough to gain confidence that a change in this repo will not inadvertently break `agoric-sdk`'s CI.