### PR TITLE
fix(loadgen): use `floorMultiplyBy`

### DIFF
--- a/loadgen/contract/agent-create-vault.js
+++ b/loadgen/contract/agent-create-vault.js
@@ -2,13 +2,14 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { AmountMath } from '@agoric/ertp';
 // import { allComparable } from '@agoric/same-structure';
-import {
-  multiplyBy,
-  makeRatio,
-} from '@agoric/zoe/src/contractSupport/index.js';
+import * as contractSupport from '@agoric/zoe/src/contractSupport/index.js';
 import { pursePetnames, issuerPetnames } from './petnames.js';
 import { disp } from './display.js';
 import { allValues } from './allValues.js';
+
+const makeRatio = contractSupport.makeRatio;
+const multiplyBy =
+  contractSupport.floorMultiplyBy || contractSupport.multiplyBy;
 
 // This is loaded by the spawner into a new 'spawned' vat on the solo node.
 // The default export function is called with some args.


### PR DESCRIPTION
Fall back to `multiplyBy`
Handle removal of deprecated API in https://github.com/Agoric/agoric-sdk/pull/4467