### PR TITLE
Save storage even when not all tasks ran

### DIFF
--- a/runner/lib/monitor/chain-monitor.js
+++ b/runner/lib/monitor/chain-monitor.js
@@ -8,7 +8,9 @@ import { PromiseAllOrErrors, warnOnRejection } from '../helpers/async.js';
 const vatIdentifierRE = /^(v\d+):(.*)$/;
 
 /**
- * @param {Pick<import("../tasks/types.js").RunKernelInfo, 'storageLocation' | 'processInfo'>} kernelInfo
+ * @param {Object} kernelInfo
+ * @param {string | void} kernelInfo.storageLocation
+ * @param {import("../helpers/procsfs.js").ProcessInfo} kernelInfo.processInfo
  * @param {Object} param1
  * @param {Console} param1.console
  * @param {import('../stats/types.js').LogPerfEvent} param1.logPerfEvent
@@ -149,11 +151,13 @@ export const makeChainMonitor = (
     return results;
   };
 
-  const logStorageUsage = async () => {
-    logPerfEvent('chain-storage-usage', {
-      chain: await dirDiskUsage(storageLocation),
-    });
-  };
+  const logStorageUsage = storageLocation
+    ? async () => {
+        logPerfEvent('chain-storage-usage', {
+          chain: await dirDiskUsage(storageLocation),
+        });
+      }
+    : async () => {};
 
   /** @type {NodeJS.Timer | null} */
   let monitorIntervalId = null;

--- a/runner/lib/tasks/local-chain.js
+++ b/runner/lib/tasks/local-chain.js
@@ -94,11 +94,11 @@ export const makeTasks = ({
     }
   };
 
-  /** @param {import("./types.js").TaskBaseOptions & {config?: {reset?: boolean, withMonitor?: boolean}}} options */
+  /** @param {import("./types.js").TaskBaseOptions & {config?: {reset?: boolean, chainOnly?: boolean, withMonitor?: boolean}}} options */
   const setupTasks = async ({
     stdout,
     stderr,
-    config: { reset, withMonitor } = {},
+    config: { reset, chainOnly, withMonitor } = {},
   }) => {
     const { console, stdio } = getConsoleAndStdio(
       'setup-tasks',
@@ -110,9 +110,14 @@ export const makeTasks = ({
       print: (cmd) => console.log(cmd),
     });
 
+    /** @type {Partial<Record<'chainStorageLocation' | 'clientStorageLocation', string>>} */
+    const storageLocations = {};
+
     console.log('Starting');
 
     if (withMonitor !== false) {
+      storageLocations.chainStorageLocation = chainStateDir;
+
       if (reset) {
         console.log('Resetting chain node');
         await childProcessDone(
@@ -121,13 +126,20 @@ export const makeTasks = ({
       }
     }
 
-    if (reset) {
-      console.log('Resetting client state');
-      await childProcessDone(
-        printerSpawn('rm', ['-rf', clientStateDir], { stdio }),
-      );
+    if (chainOnly !== true) {
+      storageLocations.clientStorageLocation = clientStateDir;
+
+      if (reset) {
+        console.log('Resetting client state');
+        await childProcessDone(
+          printerSpawn('rm', ['-rf', clientStateDir], { stdio }),
+        );
+      }
     }
+
     console.log('Done');
+
+    return harden(storageLocations);
   };
 
   /** @param {import("./types.js").TaskBaseOptions} options */

--- a/runner/lib/tasks/local-chain.js
+++ b/runner/lib/tasks/local-chain.js
@@ -237,10 +237,9 @@ export const makeTasks = ({
         });
       },
       async () => {
-        // Avoid unhandled rejections for promises that can no longer be handled
-        Promise.allSettled([done, ready]);
         launcherCp.kill();
         slogFifo.close();
+        await Promise.allSettled([done, ready]);
       },
     );
   };
@@ -471,9 +470,8 @@ export const makeTasks = ({
         });
       },
       async () => {
-        // Avoid unhandled rejections for promises that can no longer be handled
-        Promise.allSettled([done, clientStarted, walletReady]);
         soloCp.kill();
+        await Promise.allSettled([done, clientStarted, walletReady]);
       },
     );
   };

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -139,6 +139,9 @@ export const makeTasks = ({
       print: (cmd) => console.log(cmd),
     });
 
+    /** @type {Partial<Record<'chainStorageLocation' | 'clientStorageLocation', string>>} */
+    const storageLocations = {};
+
     console.log('Starting');
 
     if (testnetOriginOption) {
@@ -157,6 +160,8 @@ export const makeTasks = ({
      */ (await fetchAsJSON(`${testnetOrigin}/network-config`));
 
     if (withMonitor !== false) {
+      storageLocations.chainStorageLocation = chainStateDir;
+
       if (reset) {
         console.log('Resetting chain node');
         await childProcessDone(
@@ -206,6 +211,8 @@ export const makeTasks = ({
 
     // Make sure client is provisioned
     if (chainOnly !== true) {
+      storageLocations.clientStorageLocation = clientStateDir;
+
       if (reset) {
         console.log('Resetting client');
         await childProcessDone(
@@ -321,6 +328,8 @@ ${chainName} chain does not yet know of address ${soloAddr}
     }
 
     console.log('Done');
+
+    return harden(storageLocations);
   };
 
   /** @param {import("./types.js").TaskBaseOptions} options */

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -449,10 +449,9 @@ ${chainName} chain does not yet know of address ${soloAddr}
         });
       },
       async () => {
-        // Avoid unhandled rejections for promises that can no longer be handled
-        Promise.allSettled([done, ready]);
         chainCp.kill();
         slogFifo.close();
+        await Promise.allSettled([done, ready]);
       },
     );
   };
@@ -559,10 +558,9 @@ ${chainName} chain does not yet know of address ${soloAddr}
         });
       },
       async () => {
-        // Avoid unhandled rejections for promises that can no longer be handled
-        Promise.allSettled([done, clientStarted, walletReady]);
         soloCp.kill();
         slogFifo.close();
+        await Promise.allSettled([done, clientStarted, walletReady]);
       },
     );
   };

--- a/runner/lib/tasks/types.d.ts
+++ b/runner/lib/tasks/types.d.ts
@@ -13,6 +13,11 @@ export interface SDKBinaries {
   readonly cosmosHelper: string;
 }
 
+export type SetupTasksResult = {
+  readonly chainStorageLocation?: string;
+  readonly clientStorageLocation?: string;
+};
+
 export type TaskResult = {
   readonly stop: () => void;
   readonly done: Promise<void>;
@@ -22,7 +27,6 @@ export type TaskResult = {
 export type RunKernelInfo = {
   readonly slogLines: AsyncIterable<Buffer>;
   readonly processInfo: import('../helpers/process-info.js').ProcessInfo;
-  readonly storageLocation: string;
 };
 
 export type TaskEventStatus = Record<string, unknown> & {
@@ -66,7 +70,7 @@ export interface TaskBaseOptions {
 
 export interface OrchestratorTasks {
   getEnvInfo(options: TaskBaseOptions): Promise<EnvInfo>;
-  setupTasks(options: TaskBaseOptions): Promise<void>;
+  setupTasks(options: TaskBaseOptions): Promise<SetupTasksResult>;
   runChain(options: TaskBaseOptions): Promise<RunChainResult>;
   runClient(options: TaskBaseOptions): Promise<RunClientResult>;
   runLoadgen(options: TaskBaseOptions): Promise<RunLoadgenResult>;


### PR DESCRIPTION
While trying to debug https://github.com/Agoric/agoric-sdk/issues/4473, I realized the state dirs were not backed up on the last restart failure. That's because for historical reasons, the state dirs were only returned as part of a successful result of the tasks, which we didn't even get to.

This refactors the runner to move the state dir info to the setup stage, and backup out of the stage logic.