### PR TITLE
fix(runner): fail fast on concensus failure

### DIFF
--- a/runner/lib/helpers/stream.js
+++ b/runner/lib/helpers/stream.js
@@ -78,6 +78,7 @@ export const whenStreamSteps = (
  * @param {[unknown, import("stream").Readable, import("stream").Readable, ...unknown[]]} stdioIn
  * @param {[unknown, import("stream").Writable, import("stream").Writable, ...unknown[]]} stdioOut
  * @param {boolean} [elide]
+ * @returns {import("stream").Readable}
  */
 export const combineAndPipe = (stdioIn, stdioOut, elide = true) => {
   const combinedOutput = new PassThrough();


### PR DESCRIPTION
A chain in follow mode (`testnet`) may reach a concensus failure. In those cases the process does not stop, as the cosmos layer stay up answering RPC requests, but no further progress is made.

This change detect this case by following the chain node's stderr, and failing the task immediately if a `CONSENSUS FAILURE` is printed.