### PR TITLE
fix(runner): disable testnet chain monitor debug mode

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -74,4 +74,6 @@ jobs:
           SDK_SRC: ${{ github.workspace }}/agoric-sdk
         run: |
           ./start.sh --no-stage.save-storage --no-reset \
+            --loadgen.vault.interval=12 --loadgen.vault.limit=2 \
+            --loadgen.amm.interval=12 --loadgen.amm.wait=6 --loadgen.amm.limit=2 \
             --stages=3 --stage.duration=4

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -351,7 +351,11 @@ ${chainName} chain does not yet know of address ${soloAddr}
 
     const chainEnv = Object.create(process.env);
     chainEnv.SLOGFILE = slogFifo.path;
-    chainEnv.DEBUG = VerboseDebugEnv;
+    // DO NOT enable any debug mode for a chain which doesn't have debug enabled
+    // That's because currently any DEBUG env set changes the way vats process console
+    // logs, which causes divergences with other nodes
+    // See https://github.com/Agoric/agoric-sdk/issues/4506
+    // chainEnv.DEBUG = VerboseDebugEnv;
 
     const chainCp = printerSpawn(sdkBinaries.cosmosChain, ['start'], {
       stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
Launching a follower node in consensus mode with debug enabled causes consensus failures (see https://github.com/Agoric/agoric-sdk/issues/4506).

Until we have a consensus preserving verbose mode, remove `DEBUG` env for the testnet chain task.

Fixes https://github.com/Agoric/agoric-sdk/issues/4473