### PR TITLE
Tweak runner config and stats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/v0.209.3/containers/typescript-node/.devcontainer/Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/v0.222.0/containers/typescript-node/.devcontainer/Dockerfile
 
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
 ARG VARIANT=16-bullseye
@@ -20,41 +20,41 @@ FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT} as dev-en
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.17.4
+ENV GOLANG_VERSION 1.17.7
 
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url=; \
 	case "$arch" in \
 		'amd64') \
-			url='https://dl.google.com/go/go1.17.4.linux-amd64.tar.gz'; \
-			sha256='adab2483f644e2f8a10ae93122f0018cef525ca48d0b8764dae87cb5f4fd4206'; \
+			url='https://dl.google.com/go/go1.17.7.linux-amd64.tar.gz'; \
+			sha256='02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://dl.google.com/go/go1.17.4.linux-armv6l.tar.gz'; \
-			sha256='f34d25f818007345b716b316908115ba462f3f0dbd4343073020b544b4ae2320'; \
+			url='https://dl.google.com/go/go1.17.7.linux-armv6l.tar.gz'; \
+			sha256='874774f078b182fa21ffcb3878467eb5cb7e78bbffa6343ea5f0fbe47983433b'; \
 			;; \
 		'arm64') \
-			url='https://dl.google.com/go/go1.17.4.linux-arm64.tar.gz'; \
-			sha256='617a46bd083e59877bb5680998571b3ddd4f6dcdaf9f8bf65ad4edc8f3eafb13'; \
+			url='https://dl.google.com/go/go1.17.7.linux-arm64.tar.gz'; \
+			sha256='a5aa1ed17d45ee1d58b4a4099b12f8942acbd1dd09b2e9a6abb1c4898043c5f5'; \
 			;; \
 		'i386') \
-			url='https://dl.google.com/go/go1.17.4.linux-386.tar.gz'; \
-			sha256='276bda8e8efa59482b0be87394566e02ff7a860b65e8b6ccc90c026dbcab1f74'; \
+			url='https://dl.google.com/go/go1.17.7.linux-386.tar.gz'; \
+			sha256='5d5472672a2e0252fe31f4ec30583d9f2b320f9b9296eda430f03cbc848400ce'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://dl.google.com/go/go1.17.4.linux-ppc64le.tar.gz'; \
-			sha256='d185567480d9e335d4d9274804ef9fa796b01e53c7290a744871d0c0fac2f248'; \
+			url='https://dl.google.com/go/go1.17.7.linux-ppc64le.tar.gz'; \
+			sha256='2262fdee9147eb61fd1e719cfd19b9c035009c14890de02b5a77071b0a577405'; \
 			;; \
 		's390x') \
-			url='https://dl.google.com/go/go1.17.4.linux-s390x.tar.gz'; \
-			sha256='63e4e2065aa3139b4d9a203fa7e39a810f67e9f4753492726d485c17c37cd817'; \
+			url='https://dl.google.com/go/go1.17.7.linux-s390x.tar.gz'; \
+			sha256='24dd117581d592f52b4cf45d75ae68a6a1e42691a8671a2d3c2ddd739894a1e4'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -62,8 +62,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.17.4.src.tar.gz'; \
-		sha256='4bef3699381ef09e075628504187416565d710660fec65b057edf1ceb187fc4b'; \
+		url='https://dl.google.com/go/go1.17.7.src.tar.gz'; \
+		sha256='c108cd33b73b1911a02b697741df3dea43e01a5c4e08e409e8b3a0e3745d2b4d'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
 		echo >&2; \
@@ -127,7 +127,7 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 #WORKDIR $GOPATH
 
 ##############################
-# From https://github.com/microsoft/vscode-dev-containers/blob/v0.209.3/containers/go/.devcontainer/base.Dockerfile
+# From https://github.com/microsoft/vscode-dev-containers/blob/v0.222.0/containers/go/.devcontainer/base.Dockerfile
 
 COPY library-scripts/go-debian.sh /tmp/library-scripts/
 

--- a/library-scripts/go-debian.sh
+++ b/library-scripts/go-debian.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# From https://github.com/microsoft/vscode-dev-containers/blob/v0.222.0/containers/go/.devcontainer/library-scripts/go-debian.sh
+
 #-------------------------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
@@ -164,8 +167,28 @@ if [ "${TARGET_GO_VERSION}" != "none" ] && ! type go > /dev/null 2>&1; then
     curl -sSL -o /tmp/tmp-gnupg/golang_key "${GO_GPG_KEY_URI}"
     gpg -q --import /tmp/tmp-gnupg/golang_key
     echo "Downloading Go ${TARGET_GO_VERSION}..."
-    curl -sSL -o /tmp/go.tar.gz "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz"
-    curl -sSL -o /tmp/go.tar.gz.asc "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz.asc"
+    set +e
+    curl -fsSL -o /tmp/go.tar.gz "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz"
+    set -e
+    if [ ! -s "/tmp/go.tar.gz" ] || [ "$?" != "0" ]; then
+        echo "(!) Download failed."
+        # Try one break fix version number less if we get a failure
+        major="$(echo "${TARGET_GO_VERSION}" | grep -oE '^[0-9]+')"
+        minor="$(echo "${TARGET_GO_VERSION}" | grep -oP '^[0-9]+\.\K[0-9]+')"
+        breakfix="$(echo "${TARGET_GO_VERSION}" | grep -oP '^[0-9]+\.[0-9]+\.\K[0-9]+' 2>/dev/null)"
+        if [ "${breakfix}" = "" ] || [ "${breakfix}" = "0" ]; then
+            ((minor=minor-1))
+            TARGET_GO_VERSION="${major}.${minor}"
+            find_version_from_git_tags TARGET_GO_VERSION "https://go.googlesource.com/go" "tags/go" "." "true"
+        else 
+            ((breakfix=breakfix-1))
+           TARGET_GO_VERSION="${major}.${minor}.${breakfix}"
+        fi
+        echo "Trying ${TARGET_GO_VERSION}..."
+        curl -fsSL -o /tmp/go.tar.gz "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz"
+    fi
+    set -e
+    curl -fsSL -o /tmp/go.tar.gz.asc "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz.asc"
     gpg --verify /tmp/go.tar.gz.asc /tmp/go.tar.gz
     echo "Extracting Go ${TARGET_GO_VERSION}..."
     tar -xzf /tmp/go.tar.gz -C "${TARGET_GOROOT}" --strip-components=1
@@ -175,8 +198,7 @@ else
 fi
 
 # Install Go tools that are isImportant && !replacedByGopls based on
-# https://github.com/golang/vscode-go/blob/0ff533d408e4eb8ea54ce84d6efa8b2524d62873/src/goToolsInformation.ts
-# Exception `dlv-dap` is a copy of github.com/go-delve/delve/cmd/dlv built from the master.
+# https://github.com/golang/vscode-go/blob/v0.31.1/src/goToolsInformation.ts
 GO_TOOLS="\
     golang.org/x/tools/gopls@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \
@@ -206,10 +228,6 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
 
     # Move Go tools into path and clean up
     mv /tmp/gotools/bin/* ${TARGET_GOPATH}/bin/
-
-    # install dlv-dap (dlv@master)
-    go ${go_install_command} -v github.com/go-delve/delve/cmd/dlv@master 2>&1 | tee -a /usr/local/etc/vscode-dev-containers/go.log
-    mv /tmp/gotools/bin/dlv ${TARGET_GOPATH}/bin/dlv-dap
 
     rm -rf /tmp/gotools
 fi

--- a/loadgen/loop.js
+++ b/loadgen/loop.js
@@ -1,5 +1,4 @@
 /* global setInterval clearInterval setTimeout clearTimeout */
-/* eslint-disable no-continue */
 
 import { performance } from 'perf_hooks';
 import http from 'http';

--- a/runner/lib/helpers/buffer-line-transform.d.ts
+++ b/runner/lib/helpers/buffer-line-transform.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef,no-unused-vars */
+/* global Buffer, BufferEncoding */
 
 /// <reference types="node" />
 

--- a/runner/lib/helpers/buffer-line-transform.js
+++ b/runner/lib/helpers/buffer-line-transform.js
@@ -1,5 +1,5 @@
 /* global Buffer */
-/* eslint-disable no-underscore-dangle,no-nested-ternary,no-plusplus */
+/* eslint-disable no-underscore-dangle */
 
 import { Transform } from 'stream';
 

--- a/runner/lib/helpers/elided-buffer-line-transform.d.ts
+++ b/runner/lib/helpers/elided-buffer-line-transform.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef,no-unused-vars */
+/* global Buffer */
 
 import BufferLineTransform from './buffer-line-transform.js';
 import type { BufferLineTransformOptions } from './buffer-line-transform.js';

--- a/runner/lib/helpers/line-stream-transform.d.ts
+++ b/runner/lib/helpers/line-stream-transform.d.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import type ReadlineTransform, {
   ReadlineTransformOptions,
 } from 'readline-transform';

--- a/runner/lib/helpers/types.d.ts
+++ b/runner/lib/helpers/types.d.ts
@@ -1,5 +1,4 @@
 /* global Buffer */
-/* eslint-disable no-unused-vars,no-redeclare */
 
 import type { ChildProcessByStdio } from 'child_process';
 import type { Readable } from 'stream';

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -46,7 +46,7 @@ const defaultLoadgenConfig = {
   amm: { wait: 6, interval: 12, limit: 10 },
 };
 const defaultMonitorIntervalMinutes = 5;
-const defaultStageDurationMinutes = 6 * 60;
+const defaultStageDurationMinutes = 30;
 const defaultNumberStages = 4 + 2;
 
 /**

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -701,6 +701,7 @@ const main = async (progName, rawArgs, powers) => {
       stats.recordReady(timeSource.getTime());
       logPerfEvent('stage-ready');
       await nextStep(sleeping).finally(sleepCancel.resolve);
+      stats.recordShutdown(timeSource.getTime());
       logPerfEvent('stage-shutdown');
     };
 

--- a/runner/lib/stats/blocks.js
+++ b/runner/lib/stats/blocks.js
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-object-spread */
-
 import {
   makeRawStats,
   cloneData,

--- a/runner/lib/stats/blocks.js
+++ b/runner/lib/stats/blocks.js
@@ -12,6 +12,7 @@ import {
 /**
  * @typedef {|
  *   'liveMode' |
+ *   'beforeShutdown' |
  *   'beginAt' |
  *   'endStartAt' |
  *   'endFinishAt' |
@@ -35,6 +36,7 @@ import {
 /** @type {import('./helpers.js').RawStatInit<BlockStats,RawBlockStatsProps>} */
 const rawBlockStatsInit = {
   liveMode: null,
+  beforeShutdown: null,
   beginAt: null,
   endStartAt: null,
   endFinishAt: null,
@@ -163,6 +165,7 @@ export const makeBlockStats = (data, stageStats) => {
     privateSetters.slogLines(0);
     if (stageStats) {
       privateSetters.liveMode(stageStats.chainReadyAt != null);
+      privateSetters.beforeShutdown(stageStats.shutdownAt == null);
     }
   };
 

--- a/runner/lib/stats/cycles.js
+++ b/runner/lib/stats/cycles.js
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-object-spread */
-
 import {
   makeRawStats,
   makeGetters,

--- a/runner/lib/stats/helpers.d.ts
+++ b/runner/lib/stats/helpers.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-unused-vars,no-redeclare */
+/* eslint-disable no-redeclare */
 
 export type RawStatInitDescDefault<T> = {
   readonly default: T;

--- a/runner/lib/stats/run.js
+++ b/runner/lib/stats/run.js
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-object-spread */
-
 import { makeBlockStatsSummary } from './blocks.js';
 import { makeCycleStatsSummary } from './cycles.js';
 import {

--- a/runner/lib/stats/stages.js
+++ b/runner/lib/stats/stages.js
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-object-spread */
-
 import {
   makeRawStats,
   makeStatsCollection,

--- a/runner/lib/stats/stages.js
+++ b/runner/lib/stats/stages.js
@@ -30,6 +30,7 @@ import {
  *   'lastBlockHeight' |
  *   'startedAt' |
  *   'readyAt' |
+ *   'shutdownAt' |
  *   'endedAt' |
  *   'chainStartedAt' |
  *   'chainReadyAt' |
@@ -50,6 +51,7 @@ const rawStageStatsInit = {
   },
   startedAt: null,
   readyAt: null,
+  shutdownAt: null,
   endedAt: null,
   chainStartedAt: null,
   chainReadyAt: null,
@@ -165,8 +167,13 @@ export const getBlocksSummaries = (allBlocks) => {
     String(liveMode),
   );
 
+  const hasShutdownInfo = allBlocks[0].beforeShutdown != null;
+  const last100BeforeShutdown = allBlocks
+    .filter(({ beforeShutdown }) => !hasShutdownInfo || beforeShutdown)
+    .slice(-100);
+
   setBlocksSummary('all', generateBlocksSummary(allBlocks));
-  setBlocksSummary('last100', generateBlocksSummary(allBlocks.slice(-100)));
+  setBlocksSummary('last100', generateBlocksSummary(last100BeforeShutdown));
   setBlocksSummary('onlyLive', generateBlocksSummary(blocksByLiveMode.true));
   setBlocksSummary(
     'onlyCatchup',
@@ -272,6 +279,7 @@ export const makeStageStats = (data) => {
       {
         recordStart: privateSetters.startedAt,
         recordReady: privateSetters.readyAt,
+        recordShutdown: privateSetters.shutdownAt,
         recordEnd,
         recordChainStart: privateSetters.chainStartedAt,
         recordChainReady: privateSetters.chainReadyAt,

--- a/runner/lib/stats/types.d.ts
+++ b/runner/lib/stats/types.d.ts
@@ -27,6 +27,7 @@ export interface BlockStats extends BlockStatsInitData {
   recordSlogLine(): void;
   recordDelivery(data: BlockDeliveryData): void;
   readonly liveMode: boolean | undefined;
+  readonly beforeShutdown: boolean | undefined;
   readonly beginAt: TimeValueS | undefined;
   readonly endStartAt: TimeValueS | undefined;
   readonly endFinishAt: TimeValueS | undefined;
@@ -118,6 +119,7 @@ export type StageBlocksSummaryType =
 export interface StageStats extends StageStatsInitData {
   recordStart(time: TimeValueS): void;
   recordReady(time: TimeValueS): void;
+  recordShutdown(time: TimeValueS): void;
   recordEnd(time: TimeValueS): void;
   recordChainStart(time: TimeValueS): void;
   recordChainReady(time: TimeValueS): void;
@@ -141,6 +143,7 @@ export interface StageStats extends StageStatsInitData {
   readonly lastBlockHeight: number | undefined;
   readonly startedAt: TimeValueS | undefined;
   readonly readyAt: TimeValueS | undefined;
+  readonly shutdownAt: TimeValueS | undefined;
   readonly endedAt: TimeValueS | undefined;
   readonly readyDuration: number | undefined;
   readonly duration: number | undefined;

--- a/runner/lib/stats/types.d.ts
+++ b/runner/lib/stats/types.d.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars,no-redeclare */
-
 import type { TimeValueS } from '../helpers/time.js';
 
 export interface LogPerfEvent {

--- a/runner/lib/tasks/shared-loadgen.js
+++ b/runner/lib/tasks/shared-loadgen.js
@@ -48,16 +48,16 @@ export const makeLoadgenTask = ({ spawn }) => {
       detached: true,
     });
 
-    let stopped = false;
+    const ignoreKill = {
+      signal: false,
+    };
+
     const stop = () => {
-      stopped = true;
+      ignoreKill.signal = true;
       launcherCp.kill();
     };
 
-    // Load gen exit with non-zero code when killed
-    const loadgenDone = childProcessDone(launcherCp).catch((err) =>
-      stopped ? 0 : Promise.reject(err),
-    );
+    const loadgenDone = childProcessDone(launcherCp, { ignoreKill });
 
     loadgenDone.then(
       () => console.log('Load gen app stopped successfully'),

--- a/runner/lib/tasks/types.d.ts
+++ b/runner/lib/tasks/types.d.ts
@@ -1,5 +1,4 @@
 /* global Buffer */
-/* eslint-disable no-unused-vars,no-redeclare */
 
 import type { TimeValueS } from '../helpers/time.js';
 

--- a/scripts/run-daily-perf.sh
+++ b/scripts/run-daily-perf.sh
@@ -14,4 +14,4 @@ next_revision() {
 
 . $(dirname "$(readlink -f -- "$0")")/common-queue.sh
 
-start "daily-perf" next_revision "$@"
+start "daily-perf" next_revision --stages=12 --stage.duration=120 "$@"

--- a/scripts/run-manual.sh
+++ b/scripts/run-manual.sh
@@ -16,8 +16,10 @@ next_revision() {
 INPUT=$1
 shift
 
+DEFAULT_CONFIG="--stages=6 --stage.duration=30"
+
 if [ "x$INPUT" != "x-" ]; then
-  start "manual" next_revision "$@" 3<$INPUT
+  start "manual" next_revision $DEFAULT_CONFIG "$@" 3<$INPUT
 else
-  start "manual" next_revision "$@" 3<&0
+  start "manual" next_revision $DEFAULT_CONFIG "$@" 3<&0
 fi


### PR DESCRIPTION
Change the default stage times for the base runner and daily perf tests, and standardize the manual test times. Fixes #66 

Capture the stage shutdown time in stats, and generate the last 100 blocks summary to only consider blocks before winddown. Fixes #65 

Update docker image scripts to incorporate an upstream fix.

Drive by fixes of some outdated eslint disables.