### PR TITLE
Setup chain in setup task for local-chain

### DIFF
--- a/runner/lib/helpers/stream.js
+++ b/runner/lib/helpers/stream.js
@@ -108,6 +108,9 @@ export const combineAndPipe = (stdioIn, stdioOut, elide = true) => {
   };
   outLines.once('end', sourceEnd);
   errLines.once('end', sourceEnd);
+  combinedOutput.once('finish', () => {
+    combinedOutput.destroy();
+  });
   combinedOutput.once('close', () => {
     outLines.unpipe(combinedOutput);
     errLines.unpipe(combinedOutput);


### PR DESCRIPTION
Use the agoric cli only in the setup task to initialize the home / state dir. Launch the chain task directly using the `cosmosChain` binary instead of using the cli, making `local-chain` more similar to `testnet`.

If the cli doesn't support `--no-restart` for `local-chain` (feature pending), kill the chain immediately before it does any actual work.