### PR TITLE
Rewrite loadgen to use a dedicated asset

### DIFF
--- a/loadgen/config.js
+++ b/loadgen/config.js
@@ -1,3 +1,3 @@
-export const collateralToken = 'USDC';
+export const fallbackCollateralToken = 'USDC';
 
-export const tradeToken = 'USDC';
+export const fallbackTradeToken = 'USDC';

--- a/loadgen/contract/agent-create-vault.js
+++ b/loadgen/contract/agent-create-vault.js
@@ -1,50 +1,56 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { AmountMath } from '@agoric/ertp';
 // import { allComparable } from '@agoric/same-structure';
 import * as contractSupport from '@agoric/zoe/src/contractSupport/index.js';
-import { pursePetnames, issuerPetnames } from './petnames.js';
 import { disp } from './display.js';
-import { allValues } from './allValues.js';
+import { fallback } from './fallback.js';
 
 const makeRatio = contractSupport.makeRatio;
 const multiplyBy =
-  contractSupport.floorMultiplyBy || contractSupport.multiplyBy;
+  contractSupport.floorMultiplyBy ||
+  // @ts-expect-error backwards compat
+  contractSupport.multiplyBy;
 
-// This is loaded by the spawner into a new 'spawned' vat on the solo node.
-// The default export function is called with some args.
+/** @param {Purse} purse */
+async function getPurseBalance(purse) {
+  return /** @type {Promise<Amount<'nat'>>} */ (E(purse).getCurrentAmount());
+}
 
-export default async function startAgent([key, home, collateralToken]) {
-  const { zoe, scratch, agoricNames, wallet } = home;
+/**
+ * This is loaded by the spawner into a new 'spawned' vat on the solo node.
+ * The default export function is called with some args.
+ *
+ * @param {startParam} param
+ * @typedef {Awaited<ReturnType<typeof startAgent>>} Agent
+ * @typedef { Pick<import('../types').NatAssetKit, 'brand' | 'purse' | 'displayInfo' | 'name'>} AssetKit
+ * @typedef {{
+ *   runKit: AssetKit,
+ *   tokenKit: AssetKit,
+ *   vaultFactory: ERef<import('../types').VaultFactoryPublicFacet>,
+ *   zoe: ERef<ZoeService>,
+ * }} startParam
+ */
+export default async function startAgent({
+  runKit: {
+    brand: runBrand,
+    purse: runPurse,
+    displayInfo: { decimalPlaces: runDecimalPlaces },
+  },
+  tokenKit: {
+    brand: collateralBrand,
+    purse: collateralPurse,
+    displayInfo: { decimalPlaces: collateralDecimalPlaces },
+    name: collateralToken,
+  },
+  vaultFactory,
+  zoe,
+}) {
+  console.error(`create-vault: setting up tools`);
 
-  console.error(`create-vault: building tools`);
-  const {
-    runBrand,
-    collateralBrand,
-    runPurse,
-    collateralPurse,
-    treasuryInstance,
-    vaultFactoryInstance,
-  } = await allValues({
-    runBrand: E(agoricNames).lookup('brand', issuerPetnames.RUN),
-    collateralBrand: E(
-      E(wallet).getIssuer(issuerPetnames[collateralToken]),
-    ).getBrand(),
-    runPurse: E(wallet).getPurse(pursePetnames.RUN),
-    collateralPurse: E(wallet).getPurse(pursePetnames[collateralToken]),
-    treasuryInstance: E(agoricNames)
-      .lookup('instance', 'Treasury')
-      .catch(() => {}),
-    vaultFactoryInstance: E(agoricNames)
-      .lookup('instance', 'VaultFactory')
-      .catch(() => {}),
-  });
-
-  const treasuryPublicFacet = E(zoe).getPublicFacet(
-    vaultFactoryInstance || treasuryInstance,
-  );
-
-  const collateralBalance = await E(collateralPurse).getCurrentAmount();
+  const collateralBalance = await getPurseBalance(collateralPurse);
   if (AmountMath.isEmpty(collateralBalance)) {
     throw Error(
       `create-vault: getCurrentAmount(${collateralToken}) broken (says 0)`,
@@ -53,6 +59,7 @@ export default async function startAgent([key, home, collateralToken]) {
   console.error(
     `create-vault: initial balance: ${disp(
       collateralBalance,
+      collateralDecimalPlaces,
     )} ${collateralToken}`,
   );
   // put 1% into the vault
@@ -63,25 +70,26 @@ export default async function startAgent([key, home, collateralToken]) {
 
   // we only withdraw half the value of the collateral, giving us 200%
   // collateralization
-  const collaterals = await E(treasuryPublicFacet).getCollaterals();
+  const collaterals = await E(vaultFactory).getCollaterals();
   const cdata = collaterals.find((c) => c.brand === collateralBrand);
   const priceRate = cdata.marketPrice;
   const half = makeRatio(BigInt(50), runBrand);
   const wantedRun = multiplyBy(multiplyBy(collateralToLock, priceRate), half);
 
-  console.error(`create-vault: tools installed`);
+  console.error(`create-vault: tools ready`);
 
   console.error(
     `create-vault: collateralToLock=${disp(
       collateralToLock,
-    )} ${collateralToken}, wantedRun=${disp(wantedRun)}`,
+      collateralDecimalPlaces,
+    )} ${collateralToken}, wantedRun=${disp(wantedRun, runDecimalPlaces)}`,
   );
 
   // we fix the 1% 'collateralToLock' value at startup, and use it for all cycles
   // (we close over 'collateralToLock')
   async function openVault() {
-    console.error('create-vault: openVault');
-    const openInvitationP = E(treasuryPublicFacet).makeLoanInvitation();
+    console.error('create-vault: cycle: openVault');
+    const openInvitationP = E(vaultFactory).makeLoanInvitation();
     const proposal = harden({
       give: {
         Collateral: collateralToLock,
@@ -104,13 +112,16 @@ export default async function startAgent([key, home, collateralToken]) {
       E(runPurse).deposit(runPayout),
     ]);
     const offerResult = await E(seatP).getOfferResult();
-    console.error(`create-vault: vault opened`);
+    console.error(`create-vault: cycle: vault opened`);
     return offerResult.vault;
   }
 
   async function closeVault(vault) {
     console.error('create-vault: closeVault');
-    const runNeeded = await E(vault).getDebtAmount();
+    const runNeeded = await fallback(
+      E(vault).getCurrentDebt(),
+      E(vault).getDebtAmount(),
+    );
     const closeInvitationP = E(vault).makeCloseInvitation();
     const proposal = {
       give: {
@@ -131,23 +142,29 @@ export default async function startAgent([key, home, collateralToken]) {
       E(collateralPurse).deposit(collateralPayout),
       E(seatP).getOfferResult(),
     ]);
-    console.error(`create-vault: vault closed`);
+    console.error(`create-vault: cycle: vault closed`);
   }
 
   const agent = Far('vault agent', {
     async doVaultCycle() {
-      const vault = await openVault(collateralToLock);
+      const vault = await openVault();
       await closeVault(vault);
       const [newRunBalance, newCollateralBalance] = await Promise.all([
-        E(runPurse).getCurrentAmount(),
-        E(collateralPurse).getCurrentAmount(),
+        getPurseBalance(runPurse),
+        getPurseBalance(collateralPurse),
       ]);
-      console.error('create-vault: cycle done');
-      return [newRunBalance, newCollateralBalance];
+      console.error('create-vault: cycle: done');
+      return {
+        newRunBalanceDisplay: disp(newRunBalance, runDecimalPlaces),
+        newCollateralBalanceDisplay: disp(
+          newCollateralBalance,
+          collateralDecimalPlaces,
+        ),
+        collateralToken,
+      };
     },
   });
 
-  await E(scratch).set(key, agent);
   console.error('create-vault: ready for cycles');
   return agent;
 }

--- a/loadgen/contract/agent-prepare-loadgen.js
+++ b/loadgen/contract/agent-prepare-loadgen.js
@@ -1,16 +1,20 @@
 // @ts-check
 
-import { AssetKind } from '@agoric/ertp';
+import { AmountMath, AssetKind } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
+import { makeAsyncIterableFromNotifier } from '@agoric/notifier';
 
 import { pursePetnames, issuerPetnames } from './petnames.js';
 import { allValues } from './allValues.js';
+
+import { disp } from './display.js';
 
 /** @template T @typedef {import('@agoric/eventual-send').ERef<T>} ERef */
 
 /** @typedef {Awaited<ReturnType<typeof startAgent>>} LoadgenKit */
 /**
  * @typedef {{
+ *   faucet: ERef<any>,
  *   wallet: ERef<import('../types.js').HomeWallet>,
  *   zoe: ERef<ZoeService>,
  *   mintBundle: BundleSource,
@@ -23,14 +27,154 @@ const tokenBrandPetname = 'LGT';
 // The default export function is called with some args.
 
 /**
+ * @param {Object} param0
+ * @param {ERef<WalletUser>} param0.wallet
+ * @param {ERef<WalletAdminFacet>} param0.walletAdmin
+ */
+const makePurseFinder = ({ wallet, walletAdmin }) => {
+  const purseNotifier = E(walletAdmin).getPursesNotifier();
+  const pursesStatesUpdates = makeAsyncIterableFromNotifier(purseNotifier);
+
+  /** @type {PursesFullState[][]} */
+  const previousPursesStatesUpdates = [];
+
+  return harden({
+    /**
+     * @param {Object} param0
+     * @param {string} param0.brandPetname
+     * @param {boolean} [param0.existingOnly]
+     */
+    async find({ brandPetname, existingOnly = false }) {
+      /** @type {PursesFullState | undefined} */
+      let foundPurseState;
+
+      /** @param {PursesFullState[]} pursesStates */
+      const findPurse = (pursesStates) => {
+        foundPurseState = pursesStates.find(
+          ({ brandPetname: candidateBrand, pursePetname: candidatePurse }) =>
+            candidateBrand === issuerPetnames[brandPetname] &&
+            candidatePurse === pursePetnames[brandPetname],
+        );
+        if (foundPurseState) {
+          console.error(
+            `prepare-loadgen: Found ${brandPetname} purse`,
+            foundPurseState,
+          );
+          return true;
+        }
+        return false;
+      };
+
+      for (const pursesStates of previousPursesStatesUpdates) {
+        if (findPurse(pursesStates)) {
+          break;
+        }
+      }
+
+      if (!foundPurseState) {
+        if (existingOnly) {
+          return { kit: undefined, balance: undefined };
+        }
+
+        for await (const pursesStates of pursesStatesUpdates) {
+          previousPursesStatesUpdates.push(pursesStates);
+          if (findPurse(pursesStates)) {
+            break;
+          }
+        }
+
+        // pursesStatesUpdates is an infinite iterable so
+        // the above loop will not exit until it finds a purse
+      }
+
+      const issuer = E(wallet).getIssuer(issuerPetnames[brandPetname]);
+
+      return {
+        /** @type {Promise<import('../types.js').NatAssetKit>} */
+        kit: allValues({
+          issuer,
+          brand: foundPurseState.brand,
+          purse: foundPurseState.purse,
+          name: brandPetname,
+          displayInfo: foundPurseState.displayInfo,
+        }),
+        balance: /** @type {Amount<'nat'>} */ (
+          AmountMath.make(
+            foundPurseState.brand,
+            foundPurseState.currentAmount.value,
+          )
+        ),
+      };
+    },
+  });
+};
+
+/**
  * @param {startParam} param
  */
-export default async function startAgent({ zoe, wallet, mintBundle }) {
+export default async function startAgent({ faucet, zoe, wallet, mintBundle }) {
   const walletAdmin = E(wallet).getAdminFacet();
 
+  const purseFinder = makePurseFinder({ wallet, walletAdmin });
+
+  // Get the RUN purse and initial balance from the wallet
+  // This shouldn't require, on its own, any requests to the chain as
+  // it just waits until the wallet bootstrap is sufficiently advanced
+  const { kit: runKit, balance: initialRunBalance } = E.get(
+    purseFinder.find({ brandPetname: 'RUN' }),
+  );
+
+  // Setup the fee purse if necessary and get the remaining RUN balance
+  const runBalance = (async () => {
+    const feePurse = await E(faucet)
+      .getFeePurse()
+      .catch((err) => {
+        if (err.name !== 'TypeError') {
+          throw err;
+        } else {
+          return null;
+        }
+      });
+
+    if (!feePurse) {
+      return initialRunBalance;
+    }
+
+    const run = await initialRunBalance;
+    const thirdRunAmount = AmountMath.make(run.brand, run.value / 3n);
+
+    if (AmountMath.isEmpty(run)) {
+      throw Error(`no RUN, loadgen cannot proceed`);
+    }
+
+    console.error(
+      `prepare-loadgen: depositing ${disp(thirdRunAmount)} into the fee purse`,
+    );
+    const runPurse = E.get(runKit).purse;
+    // Purse doesn't "lock" during withdrawal so we need to
+    // wait on payment before asking about balance
+    const feePayment = await E(runPurse).withdraw(thirdRunAmount);
+
+    const remainingBalance = /** @type {Promise<Amount<'nat'>>} */ (
+      E(runPurse).getCurrentAmount()
+    );
+    await E(feePurse).deposit(feePayment);
+
+    return remainingBalance;
+  })();
+
+  /**
+   * @template T
+   * @param {PromiseLike<T>} promise
+   */
+  const withFee = async (
+    promise = /** @type {Promise<any>} */ (Promise.resolve()),
+  ) => Promise.all([promise, runBalance]).then(([value]) => value);
+
   // Use Zoe to install mint for loadgen token, return kit
+  // Needs fee purse to be provisioned
   /** @type {Promise<import('../types.js').NatAssetKit>} */
-  const tokenKit = E.when(undefined, () => {
+  const tokenKit = E.when(withFee(), () => {
     console.error(
       `prepare-loadgen: installing mint bundle and doing startInstance`,
     );
@@ -75,7 +219,7 @@ export default async function startAgent({ zoe, wallet, mintBundle }) {
     });
   });
 
-  return harden(await allValues({ tokenKit }));
+  return harden(await allValues({ tokenKit, runKit }));
 
   // TODO: exit here?
 }

--- a/loadgen/contract/agent-prepare-loadgen.js
+++ b/loadgen/contract/agent-prepare-loadgen.js
@@ -8,12 +8,14 @@ import { pursePetnames, issuerPetnames } from './petnames.js';
 import { allValues } from './allValues.js';
 
 import { disp } from './display.js';
+import { fallback } from './fallback.js';
 
 /** @template T @typedef {import('@agoric/eventual-send').ERef<T>} ERef */
 
 /** @typedef {Awaited<ReturnType<typeof startAgent>>} LoadgenKit */
 /**
  * @typedef {{
+ *   agoricNames: ERef<NameHub>,
  *   faucet: ERef<any>,
  *   wallet: ERef<import('../types.js').HomeWallet>,
  *   zoe: ERef<ZoeService>,
@@ -112,7 +114,13 @@ const makePurseFinder = ({ wallet, walletAdmin }) => {
 /**
  * @param {startParam} param
  */
-export default async function startAgent({ faucet, zoe, wallet, mintBundle }) {
+export default async function startAgent({
+  agoricNames,
+  faucet,
+  zoe,
+  wallet,
+  mintBundle,
+}) {
   const walletAdmin = E(wallet).getAdminFacet();
 
   const purseFinder = makePurseFinder({ wallet, walletAdmin });
@@ -219,7 +227,109 @@ export default async function startAgent({ faucet, zoe, wallet, mintBundle }) {
     });
   });
 
-  return harden(await allValues({ tokenKit, runKit }));
+  /** @type {ERef<Instance>} */
+  const ammInstance = fallback(
+    E(agoricNames).lookup('instance', 'amm'),
+    E(agoricNames).lookup('instance', 'autoswap'),
+  );
+  // Use `when` as older versions of agoric-sdk cannot accept a promise
+  // See https://github.com/Agoric/agoric-sdk/issues/3837
+  /** @type {ERef<import('../types.js').AttenuatedAMM>} */
+  const amm = E.when(withFee(ammInstance), E(zoe).getPublicFacet);
+
+  /** @type {(() => Promise<Amount<'nat'>>)[]} */
+  const recoverFunding = [];
+  const fundingResult = E.when(runBalance, async (centralInitialBalance) => {
+    const { purse: centralPurse } = E.get(runKit);
+    const {
+      mint: secondaryMint,
+      issuer: secondaryIssuer,
+      brand: secondaryBrandP,
+      purse: secondaryPurse,
+    } = E.get(tokenKit);
+    const liquidityIssuer = E(amm).addPool(
+      secondaryIssuer,
+      issuerPetnames[tokenBrandPetname],
+    );
+    const liquidityBrandP = E(liquidityIssuer).getBrand();
+
+    if (AmountMath.isEmpty(centralInitialBalance)) {
+      throw Error(`no RUN, loadgen cannot proceed`);
+    }
+
+    /** @type {Amount<'nat'>} */
+    const centralAmount = AmountMath.make(
+      centralInitialBalance.brand,
+      centralInitialBalance.value / 2n,
+    );
+    const centralPayment = E(centralPurse).withdraw(centralAmount);
+    recoverFunding.push(async () =>
+      E.when(centralPayment, E(centralPurse).deposit),
+    );
+
+    // Each amm and vault cycle temporarily uses 1% of holdings
+    // The faucet task taps 100_000n of the loadgen token
+    // We want the faucet to represent a fraction (1% ?) of the traded amounts
+    // The computed amount will be used for both amm liquidity and initial purse funds
+    const secondaryBrand = await secondaryBrandP;
+    /** @type {Amount<'nat'>} */
+    const secondaryAmount = AmountMath.make(
+      secondaryBrand,
+      100n * 100n * 100_000n,
+    );
+    const secondaryAMMPayment = E(secondaryMint).mintPayment(secondaryAmount);
+    const secondaryPursePayment = E(secondaryMint).mintPayment(secondaryAmount);
+
+    const depositInitialSecondaryResult = E.when(
+      secondaryPursePayment,
+      E(secondaryPurse).deposit,
+    );
+    recoverFunding.push(async () =>
+      E.when(secondaryAMMPayment, E(secondaryPurse).deposit),
+    );
+
+    console.error(
+      `prepare-loadgen: Adding AMM liquidity: ${disp(
+        centralAmount,
+      )} RUN and ${disp(secondaryAmount)} ${tokenBrandPetname}`,
+    );
+
+    const liquidityBrand = await liquidityBrandP;
+
+    const proposal = harden({
+      want: { Liquidity: AmountMath.makeEmpty(liquidityBrand) },
+      give: { Secondary: secondaryAmount, Central: centralAmount },
+    });
+
+    const addLiquiditySeat = E(zoe).offer(
+      E(amm).makeAddLiquidityInvitation(),
+      proposal,
+      harden({
+        Secondary: secondaryAMMPayment,
+        Central: centralPayment,
+      }),
+    );
+
+    const addLiquidityResult = E(addLiquiditySeat).getOfferResult();
+
+    await Promise.all([depositInitialSecondaryResult, addLiquidityResult]);
+
+    return true;
+  }).catch(async (err) => {
+    console.error('prepare-loadgen: failed to fund amm', err);
+    await Promise.all(recoverFunding.map((recover) => recover())).catch(
+      (recoverError) => {
+        console.error(
+          'prepare-loadgen: failed to recover funding',
+          recoverError,
+        );
+      },
+    );
+    return false;
+  });
+
+  await fundingResult;
+  return harden(await allValues({ tokenKit, runKit, amm }));
 
   // TODO: exit here?
 }

--- a/loadgen/contract/agent-prepare-loadgen.js
+++ b/loadgen/contract/agent-prepare-loadgen.js
@@ -1,0 +1,81 @@
+// @ts-check
+
+import { AssetKind } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+
+import { pursePetnames, issuerPetnames } from './petnames.js';
+import { allValues } from './allValues.js';
+
+/** @template T @typedef {import('@agoric/eventual-send').ERef<T>} ERef */
+
+/** @typedef {Awaited<ReturnType<typeof startAgent>>} LoadgenKit */
+/**
+ * @typedef {{
+ *   wallet: ERef<import('../types.js').HomeWallet>,
+ *   zoe: ERef<ZoeService>,
+ *   mintBundle: BundleSource,
+ * }} startParam
+ */
+
+const tokenBrandPetname = 'LGT';
+
+// This is loaded by the spawner into a new 'spawned' vat on the solo node.
+// The default export function is called with some args.
+
+/**
+ * @param {startParam} param
+ */
+export default async function startAgent({ zoe, wallet, mintBundle }) {
+  const walletAdmin = E(wallet).getAdminFacet();
+
+  // Use Zoe to install mint for loadgen token, return kit
+  /** @type {Promise<import('../types.js').NatAssetKit>} */
+  const tokenKit = E.when(undefined, () => {
+    console.error(
+      `prepare-loadgen: installing mint bundle and doing startInstance`,
+    );
+
+    const displayInfo = {
+      decimalPlaces: 6,
+      assetKind: AssetKind.NAT,
+    };
+
+    /** @type {import('./mintHolder.js').CustomTerms} */
+    const customTerms = {
+      assetKind: AssetKind.NAT,
+      displayInfo,
+      keyword: tokenBrandPetname,
+    };
+
+    const installation = E(zoe).install(mintBundle);
+
+    /** @type {Promise<ReturnType<typeof import('./mintHolder.js').start>>} */
+    const startInstanceResult = E(zoe).startInstance(
+      installation,
+      undefined,
+      customTerms,
+    );
+
+    const { creatorFacet: mint, publicFacet: issuer } =
+      E.get(startInstanceResult);
+
+    return allValues({
+      name: tokenBrandPetname,
+      displayInfo,
+      mint,
+      issuer,
+      brand: E(issuer).getBrand(),
+      purse: (async () => {
+        const issuerPetname = issuerPetnames[tokenBrandPetname];
+        const pursePetname = pursePetnames[tokenBrandPetname];
+        await E(walletAdmin).addIssuer(issuerPetname, await issuer);
+        await E(walletAdmin).makeEmptyPurse(issuerPetname, pursePetname);
+        return E(wallet).getPurse(pursePetname);
+      })(),
+    });
+  });
+
+  return harden(await allValues({ tokenKit }));
+
+  // TODO: exit here?
+}

--- a/loadgen/contract/allValues.js
+++ b/loadgen/contract/allValues.js
@@ -1,4 +1,23 @@
-const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
-const { keys, values, fromEntries } = Object;
+// @ts-check
+
+const { fromEntries, entries: toEntries } = Object;
+
+/**
+ * @template {PropertyKey} K
+ * @template V
+ * @param {Iterable<[ERef<K>, ERef<V>]>} entries
+ */
+export const allEntries = async (entries) =>
+  Promise.all(Array.from(entries).map(async (entry) => Promise.all(entry)));
+
+/**
+ * @template T
+ * @param {T} obj
+ * @returns { Promise<{
+ *   [P in keyof T]: Awaited<T[P]>
+ * }> }
+ */
 export const allValues = async (obj) =>
-  fromEntries(zip(keys(obj), await Promise.all(values(obj))));
+  fromEntries(
+    await allEntries(/** @type {[any, T[keyof T]][]} */ (toEntries(obj))),
+  );

--- a/loadgen/contract/display.js
+++ b/loadgen/contract/display.js
@@ -1,7 +1,9 @@
 import { stringifyNat } from '@agoric/ui-components/src/display/natValue/stringifyNat.js';
 
-// TODO: const { decimalPlaces } = await E(brand).getDisplayInfo(); // or E(issuer)
-
-export function disp(amount) {
-  return stringifyNat(amount.value, 6, 6);
+/**
+ * @param {Amount<'nat'>} amount
+ * @param {number} [decimalPlaces]
+ */
+export function disp(amount, decimalPlaces = 6) {
+  return stringifyNat(amount.value, decimalPlaces, 6);
 }

--- a/loadgen/contract/fallback.js
+++ b/loadgen/contract/fallback.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+export const fallback = (...args) =>
+  Promise.allSettled(args).then((results) => {
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        return result.value;
+      }
+    }
+    assert.fail(
+      assert.details`Failed to get value from any of the fallbacks (${
+        /** @type {PromiseRejectedResult[]} */ (results).map(
+          ({ reason }) => reason,
+        )
+      }.`,
+    );
+  });

--- a/loadgen/contract/mintHolder.js
+++ b/loadgen/contract/mintHolder.js
@@ -1,0 +1,26 @@
+// @ts-check
+
+import { makeIssuerKit } from '@agoric/ertp';
+
+/**
+ * This contract holds one mint.
+ *
+ * @param {ZCF<CustomTerms>} zcf
+ * @returns {{ publicFacet: Issuer, creatorFacet: Mint}}
+ * @typedef {{
+ *   keyword: string,
+ *   assetKind?: AssetKind | undefined,
+ *   displayInfo?: DisplayInfo | undefined,
+ * }} CustomTerms
+ */
+export const start = (zcf) => {
+  const { keyword, assetKind, displayInfo } = zcf.getTerms();
+
+  const { mint, issuer } = makeIssuerKit(keyword, assetKind, displayInfo);
+
+  return {
+    publicFacet: issuer,
+    creatorFacet: mint,
+  };
+};
+harden(start);

--- a/loadgen/contract/package.json
+++ b/loadgen/contract/package.json
@@ -15,6 +15,7 @@
     "@agoric/ertp": "*",
     "@agoric/eventual-send": "*",
     "@agoric/marshal": "*",
+    "@agoric/notifier": "*",
     "@agoric/ui-components": "*",
     "@agoric/zoe": "*"
   },

--- a/loadgen/contract/petnames.js
+++ b/loadgen/contract/petnames.js
@@ -2,10 +2,12 @@ export const pursePetnames = {
   RUN: 'Agoric RUN currency',
   BLD: 'Agoric staking token',
   USDC: 'USD Coin',
+  LGT: 'Loadgen token',
 };
 
 export const issuerPetnames = {
   RUN: 'RUN',
   BLD: 'BLD',
   USDC: 'USDC',
+  LGT: 'Loadgen',
 };

--- a/loadgen/loop.js
+++ b/loadgen/loop.js
@@ -11,7 +11,7 @@ import { deepEquals } from './firebase/admin/helpers.js';
 
 import { prepareLoadgen } from './prepare-loadgen.js';
 import { prepareFaucet } from './task-tap-faucet.js';
-// import { prepareAMMTrade } from './task-trade-amm.js';
+import { prepareAMMTrade } from './task-trade-amm.js';
 // import { prepareVaultCycle } from './task-create-vault.js';
 
 const sortAndFilterNullish = (obj) =>
@@ -31,7 +31,7 @@ let pushHandlerBroker;
 
 let currentConfig = sortAndFilterNullish({
   faucet: null, // e.g. { interval=60, limit=1, wait=0 }
-  // amm: null, // e.g. { interval: 120}
+  amm: null, // e.g. { interval: 120}
   // vault: null, // e.g. { interval: 120, wait: 60 }
 });
 
@@ -39,11 +39,8 @@ let pushHandler = null;
 let pushBroker = null;
 
 const tasks = {
-  // we must start the AMM task before other tasks:
-  // - AMM sets up Zoe fee purse
-  // - AMM exchanges some RUN for target token, and Vault measures the balances
   faucet: [prepareFaucet],
-  // amm: [prepareAMMTrade],
+  amm: [prepareAMMTrade],
   // vault: [prepareVaultCycle],
 };
 

--- a/loadgen/loop.js
+++ b/loadgen/loop.js
@@ -12,7 +12,7 @@ import { deepEquals } from './firebase/admin/helpers.js';
 import { prepareLoadgen } from './prepare-loadgen.js';
 import { prepareFaucet } from './task-tap-faucet.js';
 import { prepareAMMTrade } from './task-trade-amm.js';
-// import { prepareVaultCycle } from './task-create-vault.js';
+import { prepareVaultCycle } from './task-create-vault.js';
 
 const sortAndFilterNullish = (obj) =>
   Object.fromEntries(
@@ -32,7 +32,7 @@ let pushHandlerBroker;
 let currentConfig = sortAndFilterNullish({
   faucet: null, // e.g. { interval=60, limit=1, wait=0 }
   amm: null, // e.g. { interval: 120}
-  // vault: null, // e.g. { interval: 120, wait: 60 }
+  vault: null, // e.g. { interval: 120, wait: 60 }
 });
 
 let pushHandler = null;
@@ -41,7 +41,7 @@ let pushBroker = null;
 const tasks = {
   faucet: [prepareFaucet],
   amm: [prepareAMMTrade],
-  // vault: [prepareVaultCycle],
+  vault: [prepareVaultCycle],
 };
 
 const runners = {}; // name -> { cycle, stop?, limit, pending }

--- a/loadgen/loop.js
+++ b/loadgen/loop.js
@@ -9,8 +9,8 @@ import { makeAuthBroker } from './firebase/auth.js';
 import { makeClientConnectionHandlerFactory } from './firebase/client.js';
 import { deepEquals } from './firebase/admin/helpers.js';
 
-import { prepareAMMTrade } from './task-trade-amm';
-import { prepareVaultCycle } from './task-create-vault';
+// import { prepareAMMTrade } from './task-trade-amm';
+// import { prepareVaultCycle } from './task-create-vault';
 import { prepareFaucet } from './task-tap-faucet';
 
 const sortAndFilterNullish = (obj) =>
@@ -30,8 +30,8 @@ let pushHandlerBroker;
 
 let currentConfig = sortAndFilterNullish({
   faucet: null, // e.g. { interval=60, limit=1, wait=0 }
-  amm: null, // e.g. { interval: 120}
-  vault: null, // e.g. { interval: 120, wait: 60 }
+  // amm: null, // e.g. { interval: 120}
+  // vault: null, // e.g. { interval: 120, wait: 60 }
 });
 
 let pushHandler = null;
@@ -41,9 +41,9 @@ const tasks = {
   // we must start the AMM task before other tasks:
   // - AMM sets up Zoe fee purse
   // - AMM exchanges some RUN for target token, and Vault measures the balances
-  amm: [prepareAMMTrade],
-  vault: [prepareVaultCycle],
   faucet: [prepareFaucet],
+  // amm: [prepareAMMTrade],
+  // vault: [prepareVaultCycle],
 };
 
 const runners = {}; // name -> { cycle, stop?, limit, pending }

--- a/loadgen/loop.js
+++ b/loadgen/loop.js
@@ -9,9 +9,10 @@ import { makeAuthBroker } from './firebase/auth.js';
 import { makeClientConnectionHandlerFactory } from './firebase/client.js';
 import { deepEquals } from './firebase/admin/helpers.js';
 
-// import { prepareAMMTrade } from './task-trade-amm';
-// import { prepareVaultCycle } from './task-create-vault';
-import { prepareFaucet } from './task-tap-faucet';
+import { prepareLoadgen } from './prepare-loadgen.js';
+import { prepareFaucet } from './task-tap-faucet.js';
+// import { prepareAMMTrade } from './task-trade-amm.js';
+// import { prepareVaultCycle } from './task-create-vault.js';
 
 const sortAndFilterNullish = (obj) =>
   Object.fromEntries(
@@ -259,6 +260,11 @@ async function startServer() {
   });
 }
 
+/**
+ *
+ * @param { ERef<import('./types').Home> } homePromise
+ * @param { import('./types').DeployPowers } deployPowers
+ */
 export default async function runCycles(homePromise, deployPowers) {
   // const home = await homePromise;
   // console.log(`got home`);
@@ -267,13 +273,15 @@ export default async function runCycles(homePromise, deployPowers) {
   // console.log(`got chain time:`, time);
   // return;
 
+  await prepareLoadgen(homePromise, deployPowers);
+
   for (const [name, [prepare]] of Object.entries(tasks)) {
     // eslint-disable-next-line no-await-in-loop
     const cycle = await prepare(homePromise, deployPowers);
     runners[name] = { cycle, limit: 0, pending: 0, stop: undefined };
     status[name] = { active: 0, succeeded: 0, failed: 0, next: 0 };
   }
-  const { myAddressNameAdmin } = await homePromise;
+  const { myAddressNameAdmin } = E.get(homePromise);
   const myAddr = await E(myAddressNameAdmin).getMyAddress();
   const connectionHandlerFactory = makeClientConnectionHandlerFactory(myAddr);
   pushHandlerBroker = makeAuthBroker(connectionHandlerFactory);

--- a/loadgen/package.json
+++ b/loadgen/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@agoric/bundle-source": "*"
+  },
   "dependencies": {
     "@agoric/eventual-send": "*",
     "@agoric/install-ses": "*",

--- a/loadgen/prepare-loadgen.js
+++ b/loadgen/prepare-loadgen.js
@@ -1,0 +1,69 @@
+// @ts-check
+
+/* global __dirname */
+import path from 'path';
+import { E } from '@agoric/eventual-send';
+
+const key = 'loadgenKit';
+
+/**
+ * Create and save the loadgen kit if necessary
+ *
+ * @param { ERef<Pick<import('./types').Home, UsedHomeCaps>> } home
+ * @param { import('./types').DeployPowers } deployPowers
+ * @typedef {|
+ *   'scratch' |
+ *   'spawner' |
+ *   'wallet' |
+ *   'zoe' |
+ * never} UsedHomeCaps
+ */
+export async function prepareLoadgen(home, deployPowers) {
+  const { scratch, spawner, wallet, zoe } = E.get(home);
+
+  /** @type {import('./contract/agent-prepare-loadgen').LoadgenKit | undefined} */
+  let loadgenKit = await E(scratch).get(key);
+  if (!loadgenKit) {
+    const { bundleSource } = deployPowers;
+    const mintFn = path.join(__dirname, 'contract', 'mintHolder.js');
+    const mintBundle = await bundleSource(mintFn);
+
+    const agentFn = path.join(
+      __dirname,
+      'contract',
+      'agent-prepare-loadgen.js',
+    );
+    const agentBundle = await bundleSource(agentFn);
+
+    console.log(
+      `prepare-loadgen: prepare: mint bundle ${
+        JSON.stringify(mintBundle).length
+      }, agent bundle ${JSON.stringify(agentBundle).length}`,
+    );
+    // create a solo-side agent to setup everything
+    const installerP = E(spawner).install(agentBundle);
+    /** @type {import('./contract/agent-prepare-loadgen').startParam} */
+    const agentParam = harden({ wallet, zoe, mintBundle });
+    loadgenKit = await E(installerP).spawn(agentParam);
+
+    await E(scratch).set(key, loadgenKit);
+
+    console.error(`prepare-loadgen: prepare: loadgen kit ready`);
+  }
+}
+
+/**
+ * Get the loadgen kit
+ *
+ * @param { ERef<Pick<import('./types').Home, 'scratch'>> } home
+ */
+export async function getLoadgenKit(home) {
+  const { scratch } = E.get(home);
+
+  /** @type {import('./contract/agent-prepare-loadgen').LoadgenKit | undefined} */
+  const loadgenKit = await E(scratch).get(key);
+  if (!loadgenKit) {
+    throw new Error('Not initialized');
+  }
+  return loadgenKit;
+}

--- a/loadgen/prepare-loadgen.js
+++ b/loadgen/prepare-loadgen.js
@@ -14,14 +14,25 @@ const key = 'loadgenKit';
  * @typedef {|
  *   'agoricNames' |
  *   'faucet' |
+ *   'priceAuthorityAdminFacet' |
  *   'scratch' |
  *   'spawner' |
+ *   'vaultFactoryCreatorFacet' |
  *   'wallet' |
  *   'zoe' |
  * never} UsedHomeCaps
  */
 export async function prepareLoadgen(home, deployPowers) {
-  const { agoricNames, faucet, scratch, spawner, wallet, zoe } = E.get(home);
+  const {
+    agoricNames,
+    faucet,
+    priceAuthorityAdminFacet,
+    scratch,
+    spawner,
+    vaultFactoryCreatorFacet,
+    wallet,
+    zoe,
+  } = E.get(home);
 
   /** @type {import('./contract/agent-prepare-loadgen').LoadgenKit | undefined} */
   let loadgenKit = await E(scratch).get(key);
@@ -45,7 +56,15 @@ export async function prepareLoadgen(home, deployPowers) {
     // create a solo-side agent to setup everything
     const installerP = E(spawner).install(agentBundle);
     /** @type {import('./contract/agent-prepare-loadgen').startParam} */
-    const agentParam = harden({ agoricNames, faucet, wallet, zoe, mintBundle });
+    const agentParam = harden({
+      agoricNames,
+      faucet,
+      priceAuthorityAdminFacet,
+      vaultFactoryCreatorFacet,
+      wallet,
+      zoe,
+      mintBundle,
+    });
     loadgenKit = await E(installerP).spawn(agentParam);
 
     await E(scratch).set(key, loadgenKit);

--- a/loadgen/prepare-loadgen.js
+++ b/loadgen/prepare-loadgen.js
@@ -4,6 +4,8 @@
 import path from 'path';
 import { E } from '@agoric/eventual-send';
 
+import { fallbackCollateralToken, fallbackTradeToken } from './config.js';
+
 const key = 'loadgenKit';
 
 /**
@@ -64,6 +66,8 @@ export async function prepareLoadgen(home, deployPowers) {
       wallet,
       zoe,
       mintBundle,
+      fallbackCollateralToken,
+      fallbackTradeToken,
     });
     loadgenKit = await E(installerP).spawn(agentParam);
 

--- a/loadgen/prepare-loadgen.js
+++ b/loadgen/prepare-loadgen.js
@@ -12,6 +12,7 @@ const key = 'loadgenKit';
  * @param { ERef<Pick<import('./types').Home, UsedHomeCaps>> } home
  * @param { import('./types').DeployPowers } deployPowers
  * @typedef {|
+ *   'faucet' |
  *   'scratch' |
  *   'spawner' |
  *   'wallet' |
@@ -19,7 +20,7 @@ const key = 'loadgenKit';
  * never} UsedHomeCaps
  */
 export async function prepareLoadgen(home, deployPowers) {
-  const { scratch, spawner, wallet, zoe } = E.get(home);
+  const { faucet, scratch, spawner, wallet, zoe } = E.get(home);
 
   /** @type {import('./contract/agent-prepare-loadgen').LoadgenKit | undefined} */
   let loadgenKit = await E(scratch).get(key);
@@ -43,7 +44,7 @@ export async function prepareLoadgen(home, deployPowers) {
     // create a solo-side agent to setup everything
     const installerP = E(spawner).install(agentBundle);
     /** @type {import('./contract/agent-prepare-loadgen').startParam} */
-    const agentParam = harden({ wallet, zoe, mintBundle });
+    const agentParam = harden({ faucet, wallet, zoe, mintBundle });
     loadgenKit = await E(installerP).spawn(agentParam);
 
     await E(scratch).set(key, loadgenKit);

--- a/loadgen/prepare-loadgen.js
+++ b/loadgen/prepare-loadgen.js
@@ -12,6 +12,7 @@ const key = 'loadgenKit';
  * @param { ERef<Pick<import('./types').Home, UsedHomeCaps>> } home
  * @param { import('./types').DeployPowers } deployPowers
  * @typedef {|
+ *   'agoricNames' |
  *   'faucet' |
  *   'scratch' |
  *   'spawner' |
@@ -20,7 +21,7 @@ const key = 'loadgenKit';
  * never} UsedHomeCaps
  */
 export async function prepareLoadgen(home, deployPowers) {
-  const { faucet, scratch, spawner, wallet, zoe } = E.get(home);
+  const { agoricNames, faucet, scratch, spawner, wallet, zoe } = E.get(home);
 
   /** @type {import('./contract/agent-prepare-loadgen').LoadgenKit | undefined} */
   let loadgenKit = await E(scratch).get(key);
@@ -44,7 +45,7 @@ export async function prepareLoadgen(home, deployPowers) {
     // create a solo-side agent to setup everything
     const installerP = E(spawner).install(agentBundle);
     /** @type {import('./contract/agent-prepare-loadgen').startParam} */
-    const agentParam = harden({ faucet, wallet, zoe, mintBundle });
+    const agentParam = harden({ agoricNames, faucet, wallet, zoe, mintBundle });
     loadgenKit = await E(installerP).spawn(agentParam);
 
     await E(scratch).set(key, loadgenKit);

--- a/loadgen/task-create-vault.js
+++ b/loadgen/task-create-vault.js
@@ -33,15 +33,24 @@ export async function prepareVaultCycle(home, deployPowers) {
 
     // create the solo-side agent to drive each cycle, let it handle zoe
     const installerP = E(spawner).install(agentBundle);
-    const { runKit, tokenKit, vaultFactory } = await loadgenKit;
-    /** @type {import('./contract/agent-create-vault').startParam} */
-    const startParam = { tokenKit, runKit, vaultFactory, zoe };
-    agent = await E(installerP).spawn(startParam);
-    await E(scratch).set(key, agent);
-    console.log(`create-vault: prepare: agent installed`);
+    const { runKit, vaultTokenKit: tokenKit, vaultFactory } = await loadgenKit;
+    if (runKit && tokenKit && vaultFactory) {
+      /** @type {import('./contract/agent-create-vault').startParam} */
+      const startParam = { tokenKit, runKit, vaultFactory, zoe };
+      agent = await E(installerP).spawn(startParam);
+      await E(scratch).set(key, agent);
+      console.log(`create-vault: prepare: agent installed`);
+    } else {
+      console.error(
+        `create-vault: prepare: couldn't install agent, missing prerequisites`,
+      );
+    }
   }
 
   async function vaultCycle() {
+    if (!agent) {
+      throw new Error('No agent available');
+    }
     const {
       newRunBalanceDisplay,
       newCollateralBalanceDisplay,

--- a/loadgen/task-create-vault.js
+++ b/loadgen/task-create-vault.js
@@ -1,8 +1,9 @@
+// @ts-check
+
 /* global __dirname */
 import path from 'path';
 import { E } from '@agoric/eventual-send';
-import { disp } from './contract/display.js';
-import { collateralToken } from './config.js';
+import { getLoadgenKit } from './prepare-loadgen.js';
 
 // Prepare to create and close a vault on each cycle. We measure our
 // available collateral token at startup. On each cycle, we deposit 1% of that value as
@@ -12,33 +13,45 @@ import { collateralToken } from './config.js';
 // cycle with slightly less collateral and RUN than we started (because of fees),
 // but with no vaults or loans outstanding.
 
-// Make sure to run this after task-trade-amm has started (which converts 50%
-// of our RUN into collateral), so we don't TOCTTOU ourselves into believing we have
-// a different amount of collateral.
-
-export async function prepareVaultCycle(homePromise, deployPowers) {
+/**
+ * set up an agent using the issuerKit and vault prepared by the loadgen
+ *
+ * @param { ERef<Pick<import('./types').Home, 'scratch' | 'spawner' | 'zoe'>> } home
+ * @param { import('./types').DeployPowers } deployPowers
+ */
+export async function prepareVaultCycle(home, deployPowers) {
   const key = 'open-close-vault';
-  const home = await homePromise;
-  const { scratch, spawner } = home;
+  const { scratch, spawner, zoe } = E.get(home);
+  /** @type {ERef<import('./contract/agent-create-vault').Agent> | undefined} */
   let agent = await E(scratch).get(key);
   if (!agent) {
+    const loadgenKit = getLoadgenKit(home);
     const { bundleSource } = deployPowers;
+
     const agentFn = path.join(__dirname, 'contract', 'agent-create-vault.js');
     const agentBundle = await bundleSource(agentFn);
+
     // create the solo-side agent to drive each cycle, let it handle zoe
     const installerP = E(spawner).install(agentBundle);
-    agent = await E(installerP).spawn([key, home, collateralToken]);
+    const { runKit, tokenKit, vaultFactory } = await loadgenKit;
+    /** @type {import('./contract/agent-create-vault').startParam} */
+    const startParam = { tokenKit, runKit, vaultFactory, zoe };
+    agent = await E(installerP).spawn(startParam);
+    await E(scratch).set(key, agent);
+    console.log(`create-vault: prepare: agent installed`);
   }
 
   async function vaultCycle() {
-    const [newRunBalance, newCollateralBalance] = await E(agent).doVaultCycle();
+    const {
+      newRunBalanceDisplay,
+      newCollateralBalanceDisplay,
+      collateralToken,
+    } = await E(agent).doVaultCycle();
     console.log(
-      `create-vault done: RUN=${disp(newRunBalance)} ${collateralToken}=${disp(
-        newCollateralBalance,
-      )}`,
+      `create-vault: new purse balances: RUN=${newRunBalanceDisplay} ${collateralToken}=${newCollateralBalanceDisplay}`,
     );
   }
 
-  console.log(`--- vault ready for cycles`);
+  console.log(`create-vault: prepare: ready for cycles`);
   return vaultCycle;
 }

--- a/loadgen/task-tap-faucet.js
+++ b/loadgen/task-tap-faucet.js
@@ -1,39 +1,47 @@
-/* global require __dirname */
+// @ts-check
+
+/* global __dirname */
 import path from 'path';
 import { E } from '@agoric/eventual-send';
 
-// set up a fungible faucet contract, and a purse to match, if they aren't already present
-export async function prepareFaucet(homePromise, deployPowers) {
+import { getLoadgenKit } from './prepare-loadgen.js';
+
+/**
+ * set up a fungible faucet purse and agent using the issuerKit prepared by the loadgen
+ *
+ * @param { ERef<Pick<import('./types').Home, 'scratch' | 'spawner'>> } home
+ * @param { import('./types').DeployPowers } deployPowers
+ */
+export async function prepareFaucet(home, deployPowers) {
   const key = 'fungible';
-  const home = await homePromise;
-  const { scratch, spawner } = home;
+  const { scratch, spawner } = E.get(home);
+  /** @type {ERef<import('./contract/agent-tap-faucet.js').Agent> | undefined} */
   let agent = await E(scratch).get(key);
   if (!agent) {
+    const loadgenKit = getLoadgenKit(home);
     const { bundleSource } = deployPowers;
-    const faucetFn = require.resolve(`@agoric/zoe/src/contracts/mintPayments`);
-    const faucetBundleP = bundleSource(faucetFn);
+
     const agentFn = path.join(__dirname, 'contract', 'agent-tap-faucet.js');
-    const agentBundleP = bundleSource(agentFn);
-    const faucetBundle = await faucetBundleP;
-    const agentBundle = await agentBundleP;
+    const agentBundle = await bundleSource(agentFn);
 
     console.log(
-      `--- prepareFaucet has bundles ${JSON.stringify(faucetBundle).length} ${
-        JSON.stringify(agentBundle).length
-      }`,
+      `faucet: prepare: agent bundle ${JSON.stringify(agentBundle).length}`,
     );
     // create the solo-side agent to drive each cycle, let it handle zoe
     const installerP = E(spawner).install(agentBundle);
-    await installerP;
-    console.log(`--- agentBundle installed`);
-    agent = await E(installerP).spawn([key, home, faucetBundle]);
+    const { tokenKit } = await loadgenKit;
+    /** @type {import('./contract/agent-tap-faucet').startParam} */
+    const startParam = { tokenKit };
+    agent = await E(installerP).spawn(startParam);
+    await E(scratch).set(key, agent);
+    console.log(`faucet: prepare: agent installed`);
   }
 
   async function faucetCycle() {
-    const amount = await E(agent).doFaucetCycle();
-    console.log(`new purse balance`, amount.value, new Date());
+    const { amountDisplay, faucetToken } = await E(agent).doFaucetCycle();
+    console.log(`faucet: new purse balance: ${faucetToken}=${amountDisplay}`);
   }
 
-  console.log(`--- prepareFaucet ready for cycles`);
+  console.log(`faucet: prepare: ready for cycles`);
   return faucetCycle;
 }

--- a/loadgen/task-trade-amm.js
+++ b/loadgen/task-trade-amm.js
@@ -26,15 +26,24 @@ export async function prepareAMMTrade(home, deployPowers) {
 
     // create the solo-side agent to drive each cycle, let it handle zoe
     const installerP = E(spawner).install(agentBundle);
-    const { runKit, tokenKit, amm } = await loadgenKit;
-    /** @type {import('./contract/agent-trade-amm').startParam} */
-    const startParam = { tokenKit, runKit, amm, zoe };
-    agent = await E(installerP).spawn(startParam);
-    await E(scratch).set(key, agent);
-    console.log(`trade-amm: prepare: agent installed`);
+    const { runKit, ammTokenKit: tokenKit, amm } = await loadgenKit;
+    if (runKit && tokenKit && amm) {
+      /** @type {import('./contract/agent-trade-amm').startParam} */
+      const startParam = { tokenKit, runKit, amm, zoe };
+      agent = await E(installerP).spawn(startParam);
+      await E(scratch).set(key, agent);
+      console.log(`trade-amm: prepare: agent installed`);
+    } else {
+      console.error(
+        `trade-amm: prepare: couldn't install agent, missing prerequisites`,
+      );
+    }
   }
 
   async function tradeAMMCycle() {
+    if (!agent) {
+      throw new Error('No agent available');
+    }
     const { newRunBalanceDisplay, newTargetBalanceDisplay, targetToken } =
       await E(agent).doAMMCycle();
     console.log(

--- a/loadgen/task-trade-amm.js
+++ b/loadgen/task-trade-amm.js
@@ -1,29 +1,46 @@
+// @ts-check
+
 /* global __dirname */
 import path from 'path';
 import { E } from '@agoric/eventual-send';
-import { tradeToken } from './config.js';
 
-// prepare to make a trade on the AMM each cycle
-export async function prepareAMMTrade(homePromise, deployPowers) {
+import { getLoadgenKit } from './prepare-loadgen.js';
+
+/**
+ * set up an agent using the issuerKit prepared by the loadgen
+ *
+ * @param { ERef<Pick<import('./types').Home, 'scratch' | 'spawner' | 'zoe'>> } home
+ * @param { import('./types').DeployPowers } deployPowers
+ */
+export async function prepareAMMTrade(home, deployPowers) {
   const key = 'trade-amm';
-  const home = await homePromise;
-  const { scratch, spawner } = home;
+  const { scratch, spawner, zoe } = E.get(home);
+  /** @type {ERef<import('./contract/agent-trade-amm').Agent> | undefined} */
   let agent = await E(scratch).get(key);
   if (!agent) {
+    const loadgenKit = getLoadgenKit(home);
     const { bundleSource } = deployPowers;
+
     const agentFn = path.join(__dirname, 'contract', 'agent-trade-amm.js');
     const agentBundle = await bundleSource(agentFn);
+
     // create the solo-side agent to drive each cycle, let it handle zoe
     const installerP = E(spawner).install(agentBundle);
-    agent = await E(installerP).spawn([key, home, tradeToken]);
+    const { runKit, tokenKit, amm } = await loadgenKit;
+    /** @type {import('./contract/agent-trade-amm').startParam} */
+    const startParam = { tokenKit, runKit, amm, zoe };
+    agent = await E(installerP).spawn(startParam);
+    await E(scratch).set(key, agent);
+    console.log(`trade-amm: prepare: agent installed`);
   }
 
   async function tradeAMMCycle() {
-    const [newRunBalance, newTargetBalance] = await E(agent).doAMMCycle();
+    const { newRunBalanceDisplay, newTargetBalanceDisplay, targetToken } =
+      await E(agent).doAMMCycle();
     console.log(
-      `trade-amm done: RUN=${newRunBalance.value} ${tradeToken}=${newTargetBalance.value}`,
+      `trade-amm: new purse balances: RUN=${newRunBalanceDisplay} ${targetToken}=${newTargetBalanceDisplay}`,
     );
   }
-  console.log(`--- trade-amm ready for cycles`);
+  console.log(`trade-amm: prepare: ready for cycles`);
   return tradeAMMCycle;
 }

--- a/loadgen/types.js
+++ b/loadgen/types.js
@@ -1,0 +1,46 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/bundle-source/src/types.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/vats/exported.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/wallet/api/exported.js';
+// Unfortunately need to dig in internal types for WalletAdminFacet
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/wallet/api/src/internal-types.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/zoe/src/contractFacet/types.js';
+
+export {};
+
+/** @typedef {ReturnType<typeof import('@agoric/solo/src/scratch.js').default>} Scratch */
+/** @typedef {ReturnType<typeof import('@agoric/spawner').makeSpawner>} Spawner */
+/** @typedef {WalletUser & { getAdminFacet: () => WalletAdminFacet }} HomeWallet */
+
+/**
+ * @template {AssetKind} [K=AssetKind]
+ * @typedef {Object} AssetKit
+ * @property {string} name
+ * @property {Mint<K>} [mint]
+ * @property {Issuer<K>} issuer
+ * @property {Brand<K>} brand
+ * @property {DisplayInfo<K>} displayInfo
+ * @property {Purse} purse
+ */
+
+/** @typedef {AssetKit<'nat'>} NatAssetKit */
+
+/**
+ * @typedef {Object} Home
+ * @property {ERef<Scratch>} scratch
+ * @property {ERef<Spawner>} spawner
+ * @property {ERef<HomeWallet>} wallet
+ * @property {ERef<ZoeService>} zoe
+ * @property {ERef<MyAddressNameAdmin>} myAddressNameAdmin
+ */
+
+/**
+ * @typedef {Object} DeployPowers
+ * @property {BundleSource} bundleSource
+ */

--- a/loadgen/types.js
+++ b/loadgen/types.js
@@ -33,6 +33,7 @@ export {};
 
 /**
  * @typedef {Object} Home
+ * @property {ERef<unknown>} faucet
  * @property {ERef<Scratch>} scratch
  * @property {ERef<Spawner>} spawner
  * @property {ERef<HomeWallet>} wallet

--- a/loadgen/types.js
+++ b/loadgen/types.js
@@ -11,6 +11,8 @@ import '@agoric/wallet/api/exported.js';
 import '@agoric/wallet/api/src/internal-types.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/src/contractFacet/types.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/run-protocol/exported.js';
 
 export {};
 
@@ -18,10 +20,13 @@ export {};
 /** @typedef {ReturnType<typeof import('@agoric/spawner').makeSpawner>} Spawner */
 /** @typedef {WalletUser & { getAdminFacet: () => WalletAdminFacet }} HomeWallet */
 
+/** @typedef { import('@agoric/run-protocol/src/vaultFactory/vaultFactory').VaultFactoryContract['publicFacet']} VaultFactoryPublicFacet */
+/** @typedef { import('@agoric/zoe/tools/priceAuthorityRegistry').PriceAuthorityRegistryAdmin } PriceAuthorityRegistryAdmin */
+
 /**
  * @typedef { Pick<
  *   XYKAMMPublicFacet,
- *   'makeSwapInInvitation' | 'makeAddLiquidityInvitation'
+ *   'getPriceAuthorities' | 'makeSwapInInvitation' | 'makeAddLiquidityInvitation'
  * > & {
  *   addPool: (issuer: ERef<Issuer>, keyword: Keyword) => Promise<Issuer>
  * } } AttenuatedAMM
@@ -46,6 +51,8 @@ export {};
  * @property {ERef<unknown>} faucet
  * @property {ERef<Scratch>} scratch
  * @property {ERef<Spawner>} spawner
+ * @property {ERef<VaultFactory>} [vaultFactoryCreatorFacet]
+ * @property {ERef<PriceAuthorityRegistryAdmin>} [priceAuthorityAdminFacet]
  * @property {ERef<HomeWallet>} wallet
  * @property {ERef<ZoeService>} zoe
  * @property {ERef<MyAddressNameAdmin>} myAddressNameAdmin

--- a/loadgen/types.js
+++ b/loadgen/types.js
@@ -19,6 +19,15 @@ export {};
 /** @typedef {WalletUser & { getAdminFacet: () => WalletAdminFacet }} HomeWallet */
 
 /**
+ * @typedef { Pick<
+ *   XYKAMMPublicFacet,
+ *   'makeSwapInInvitation' | 'makeAddLiquidityInvitation'
+ * > & {
+ *   addPool: (issuer: ERef<Issuer>, keyword: Keyword) => Promise<Issuer>
+ * } } AttenuatedAMM
+ */
+
+/**
  * @template {AssetKind} [K=AssetKind]
  * @typedef {Object} AssetKit
  * @property {string} name
@@ -33,6 +42,7 @@ export {};
 
 /**
  * @typedef {Object} Home
+ * @property {ERef<NameHub>} agoricNames
  * @property {ERef<unknown>} faucet
  * @property {ERef<Scratch>} scratch
  * @property {ERef<Spawner>} spawner

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -517,13 +517,18 @@ const main = async (progName, rawArgs, powers) => {
           const firstEmptyBlockKit = makePromiseKit();
           resolveFirstEmptyBlock = firstEmptyBlockKit.resolve;
 
-          await tryTimeout(2 * 60 * 1000, () =>
-            Promise.race([
+          await tryTimeout(2 * 60 * 1000, async () => {
+            await Promise.race([
+              done,
               slogMonitorDone,
               orInterrupt(firstBlockDoneKit.promise),
-            ]),
-          );
-          await orInterrupt(firstEmptyBlockKit.promise);
+            ]);
+            await Promise.race([
+              done,
+              slogMonitorDone,
+              orInterrupt(firstEmptyBlockKit.promise),
+            ]);
+          });
 
           await nextStep(done);
         },

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -44,6 +44,7 @@ const finished = promisify(finishedCallback);
 
 const defaultLoadgenConfig = {
   faucet: { interval: 12, limit: 10 },
+  amm: { wait: 6, interval: 12, limit: 10 },
 };
 const defaultMonitorIntervalMinutes = 5;
 const defaultStageDurationMinutes = 30;

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -42,8 +42,7 @@ const pipeline = promisify(pipelineCallback);
 const finished = promisify(finishedCallback);
 
 const defaultLoadgenConfig = {
-  vault: { interval: 12, limit: 10 },
-  amm: { wait: 6, interval: 12, limit: 10 },
+  faucet: { interval: 12, limit: 10 },
 };
 const defaultMonitorIntervalMinutes = 5;
 const defaultStageDurationMinutes = 30;

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -204,7 +204,11 @@ const main = async (progName, rawArgs, powers) => {
   const { stdout, stderr, fs, fsStream, spawn, tmpDir } = powers;
 
   // TODO: switch to full yargs for documenting output
-  const argv = yargsParser(rawArgs);
+  const argv = yargsParser(rawArgs, {
+    configuration: {
+      'duplicate-arguments-array': false,
+    },
+  });
 
   const { getProcessInfo, getCPUTimeOffset } = makeProcfsHelper({ fs, spawn });
   const { dirDiskUsage, makeFIFO } = makeFsHelper({

--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -43,7 +43,7 @@ const pipeline = promisify(pipelineCallback);
 const finished = promisify(finishedCallback);
 
 const defaultLoadgenConfig = {
-  faucet: { interval: 12, limit: 10 },
+  vault: { interval: 12, limit: 10 },
   amm: { wait: 6, interval: 12, limit: 10 },
 };
 const defaultMonitorIntervalMinutes = 5;

--- a/runner/lib/tasks/local-chain.js
+++ b/runner/lib/tasks/local-chain.js
@@ -44,7 +44,7 @@ const STAKING_DENOM = 'ubld';
 // Need to provision less than 50000 RUN as that's the most we can get from an old sdk genesis
 const SOLO_COINS = `75000000${STAKING_DENOM},40000000000${CENTRAL_DENOM}`;
 
-const VerboseDebugEnv = 'agoric';
+const VerboseDebugEnv = 'agoric,SwingSet:vat,SwingSet:ls';
 
 const chainStartRE = /ag-chain-cosmos start --home=(.*)$/;
 const chainSwingSetLaunchRE = /launch-chain: Launching SwingSet kernel$/;

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -54,6 +54,7 @@ const chainConsensusFailureBuffer = Buffer.from('CONSENSUS FAILURE');
  * @param {import("../helpers/fs.js").MakeFIFO} powers.makeFIFO Make a FIFO file readable stream
  * @param {import("../helpers/procsfs.js").GetProcessInfo} powers.getProcessInfo
  * @param {import("./types.js").SDKBinaries} powers.sdkBinaries
+ * @param {string | void} powers.loadgenBootstrapConfig
  * @returns {import("./types.js").OrchestratorTasks}
  */
 export const makeTasks = ({
@@ -62,6 +63,7 @@ export const makeTasks = ({
   makeFIFO,
   getProcessInfo,
   sdkBinaries,
+  loadgenBootstrapConfig,
 }) => {
   const spawn = makeSpawnWithPipedStream({
     spawn: cpSpawn,
@@ -117,6 +119,9 @@ export const makeTasks = ({
   );
 
   let testnetOrigin = 'https://testnet.agoric.net';
+
+  /** @type {Record<string, string>} */
+  const additionChainEnv = {};
 
   /** @param {import("./types.js").TaskBaseOptions & {config?: {reset?: boolean, chainOnly?: boolean, withMonitor?: boolean, testnetOrigin?: string}}} options */
   const setupTasks = async ({
@@ -208,6 +213,10 @@ export const makeTasks = ({
         configP2p.addr_book_strict = false;
         delete config.log_level;
         await fs.writeFile(configPath, TOML.stringify(config));
+      }
+
+      if (loadgenBootstrapConfig) {
+        additionChainEnv.CHAIN_BOOTSTRAP_VAT_CONFIG = loadgenBootstrapConfig;
       }
     }
 
@@ -327,6 +336,11 @@ ${chainName} chain does not yet know of address ${soloAddr}
       };
 
       await tryTimeout(timeout * 1000, untilProvisioned);
+
+      // TODO: Figure out how to plumb address of other loadgen client
+      if (soloAddr) {
+        additionChainEnv.VAULT_FACTORY_CONTROLLER_ADDR = soloAddr;
+      }
     }
 
     console.log('Done');
@@ -349,8 +363,10 @@ ${chainName} chain does not yet know of address ${soloAddr}
     const slogLines = new BufferLineTransform();
     const slogPipeResult = pipeline(slogFifo, slogLines);
 
-    const chainEnv = Object.create(process.env);
-    chainEnv.SLOGFILE = slogFifo.path;
+    const chainEnv = Object.assign(Object.create(process.env), {
+      ...additionChainEnv,
+      SLOGFILE: slogFifo.path,
+    });
     // DO NOT enable any debug mode for a chain which doesn't have debug enabled
     // That's because currently any DEBUG env set changes the way vats process console
     // logs, which causes divergences with other nodes

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -458,6 +458,9 @@ ${chainName} chain does not yet know of address ${soloAddr}
           await sleep(5 * 1000);
         }
       }
+
+      // Rethrow any error if stopped before ready
+      await chainDone;
     });
 
     return tryTimeout(

--- a/scripts/common-queue.sh
+++ b/scripts/common-queue.sh
@@ -2,6 +2,7 @@
 
 set -m
 
+DOCKER_IMAGE="${DOCKER_IMAGE:-loadgen-runner}"
 DOCKER_ID=
 SLEEP_PID=
 
@@ -41,7 +42,7 @@ start() {
       -e SDK_REVISION=${SDK_REVISION} \
       -e SDK_REPO=${SDK_REPO} \
       --name "${OUTPUT_DIR}" \
-      loadgen-runner \
+      "${DOCKER_IMAGE}" \
       --test-data.test-type=${TEST_TYPE} "$@" \
     ) || exit $?
     docker start ${DOCKER_ID}

--- a/scripts/run-manual.sh
+++ b/scripts/run-manual.sh
@@ -8,7 +8,7 @@ set -x
 
 next_revision() {
   read -r REPLY <&3
-  echo $REPLY
+  echo ${REPLY%% *}
 }
 
 . $(dirname "$(readlink -f -- "$0")")/common-queue.sh

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,7 +178,7 @@
   resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-4.1.0.tgz#102794e033ffc183a20b0f86031a2e76d204b9f6"
   integrity sha512-2oMoh3DMn0Fx8HChPPiH8irBNdT/33ttxAZJohhd3nU3gyBRQ1u+eEoOQWfSkrE6M02iMkQM7GE9MzGmjQ6bHg==
 
-"@agoric/notifier@^0.3.32":
+"@agoric/notifier@*", "@agoric/notifier@^0.3.32":
   version "0.3.32"
   resolved "https://registry.yarnpkg.com/@agoric/notifier/-/notifier-0.3.32.tgz#62be82f43564ec3ab986e6ea1c7d2021adbb5d51"
   integrity sha512-Z/1Azmis9V7pxSlMBCuJE7fXA0zXLc30S0tkJShp9WpyX0wZduLh6eeBqF1HS1JwE793BawIY1nvRNvGpJkr8Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,7 @@
   resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.14.3.tgz#1bf201417481d37d2797dd3283590dcbef775b4d"
   integrity sha512-Rdlxts19kvxHsqTjTrhGJv0yKgCyjCSVgXoLBZf9dZ7lyo/j+6xFQBiWjP03bXve3X74wUvA1QU55wVey8DEiQ==
 
-"@agoric/bundle-source@^2.0.1":
+"@agoric/bundle-source@*", "@agoric/bundle-source@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@agoric/bundle-source/-/bundle-source-2.0.1.tgz#30a030e5a2f934994280b4f1e489af3c39ef94e1"
   integrity sha512-3y3ZDNKNa2oWaWq8bXGtEJiVrSzVoZjZXOgFXP3GAHYnHiS9woRigvtnOu01ZFxDgpDMjLGjcXRVUK3GdYfhWA==


### PR DESCRIPTION
Closes #69 
Refs https://github.com/Agoric/agoric-sdk/issues/4634

Best reviewed commit-by-commit

https://github.com/Agoric/agoric-sdk/pull/4541 removed the AMM, VaultFactory and demo assets from the default bootstrap. While the demo config does have the AMM and VaultFactory enabled, it doesn't contain any assets the loadgen could use for its tasks.

https://github.com/Agoric/agoric-sdk/pull/4641 added the ability for the loadgen to bless an asset as usable with vaults. This PR mainly updates the loadgen to create its own asset, create an AMM pool, fund it with that asset and some RUN, and bless the asset for usage with the VaultFactory.

This PR ends up as a complete rewrite of the task prepare steps, and make major changes to the tasks themselves. Some noteworthy changes:
- Remove sending distributed objects back to the deploy script in the result of tasks (`Amount` were previously shared)
- Fix display of assets to respect decimal places
- Pipeline operations as much as possible

I have tested this change against a range of previous revisions to insure backwards compatibility. If the vaultFactoryCreator isn't available, the prepare step attempts to fallback to a demo asset (`USDC`), if available. In the worst case, the `vault` task will not be functional, but the `amm` task should always be available with the new dedicated loadgen asset.
```txt
e43902478 # grant addVaultType based on addr (03/19/2022)
22356c2b4 # Original base of addVaultType PR (02/22/2022)
492769f2f # Before change removing USDC (02/21/2022)
80f0076d5 # last known good before BLD removal? (01/24/2022)
3c4b2fb71 # After zoeFeePurse removal (12/29/2021)
01a174e88 # Zoe metering (08/17/2021)
e0f816e15 # Know good before metering (08/15/2021)
```