### PR TITLE
chore: use less deprecated makeVaultInvitation

### DIFF
--- a/loadgen/contract/agent-create-vault.js
+++ b/loadgen/contract/agent-create-vault.js
@@ -89,7 +89,7 @@ export default async function startAgent({
   // (we close over 'collateralToLock')
   async function openVault() {
     console.error('create-vault: cycle: openVault');
-    const openInvitationP = E(vaultFactory).makeLoanInvitation();
+    const openInvitationP = E(vaultFactory).makeVaultInvitation();
     const proposal = harden({
       give: {
         Collateral: collateralToLock,


### PR DESCRIPTION
Stop using deprecated `makeLoanInvitation` so I can remove it.

https://github.com/Agoric/agoric-sdk/blob/1c354ca7e12343f61f4a0cbd93cfd9b4636c23a1/packages/run-protocol/src/vaultFactory/vaultFactory.js#L257-L260

`makeVaultInvitation` is also deprecated but is easier to keep around so this adopts it.