### PR TITLE
feat(runner): Support chain and client traces

### DIFF
--- a/runner/lib/tasks/helpers.js
+++ b/runner/lib/tasks/helpers.js
@@ -161,3 +161,29 @@ export const getConsoleAndStdio = (prefix, stdout, stderr) => {
   });
   return { console, stdio: [undefined, out, err] };
 };
+
+/**
+ *
+ * @param {Pick<import('./types.js').TaskSwingSetOptions, 'trace'>} options
+ * @param {string} [envPrefix]
+ */
+export const getExtraEnvArgs = ({ trace = {} }, envPrefix = '') => {
+  /** @type {Record<string, string>} */
+  const env = {};
+  /** @type {string[]} */
+  const args = [];
+
+  if (trace.xsnap) {
+    env[`${envPrefix}XSNAP_TEST_RECORD`] = trace.xsnap;
+  }
+
+  if (trace.swingstore) {
+    env[`${envPrefix}SWING_STORE_TRACE`] = trace.swingstore;
+  }
+
+  if (trace.kvstore) {
+    args.push(`--trace-store=${trace.kvstore}`);
+  }
+
+  return { env, args };
+};

--- a/runner/lib/tasks/types.d.ts
+++ b/runner/lib/tasks/types.d.ts
@@ -67,10 +67,17 @@ export interface TaskBaseOptions {
   readonly config?: unknown;
 }
 
+export type CosmicSwingSetTracingKeys = 'xsnap' | 'kvstore' | 'swingstore';
+export interface TaskSwingSetOptions extends TaskBaseOptions {
+  readonly trace?:
+    | Partial<Record<CosmicSwingSetTracingKeys, string>>
+    | undefined;
+}
+
 export interface OrchestratorTasks {
   getEnvInfo(options: TaskBaseOptions): Promise<EnvInfo>;
   setupTasks(options: TaskBaseOptions): Promise<SetupTasksResult>;
-  runChain(options: TaskBaseOptions): Promise<RunChainResult>;
-  runClient(options: TaskBaseOptions): Promise<RunClientResult>;
+  runChain(options: TaskSwingSetOptions): Promise<RunChainResult>;
+  runClient(options: TaskSwingSetOptions): Promise<RunClientResult>;
   runLoadgen(options: TaskBaseOptions): Promise<RunLoadgenResult>;
 }


### PR DESCRIPTION
Add the ability to save traces for the kvstore, xsnap and the swingstore.

Rename the storage tarball filename for consistency.

chain swingstore and client xsnap and swingstore traces rely on https://github.com/Agoric/agoric-sdk/pull/5228, but being env additions, it's backwards compatible to add to loadgen independently.