### PR TITLE
Refactor loadgen to handle IST

### DIFF
--- a/loadgen/contract/agent-create-vault.js
+++ b/loadgen/contract/agent-create-vault.js
@@ -25,9 +25,9 @@ async function getPurseBalance(purse) {
  *
  * @param {startParam} param
  * @typedef {Awaited<ReturnType<typeof startAgent>>} Agent
- * @typedef { Pick<import('../types').NatAssetKit, 'brand' | 'purse' | 'displayInfo' | 'name'>} AssetKit
+ * @typedef { Pick<import('../types').NatAssetKit, 'brand' | 'purse' | 'displayInfo' | 'symbol'>} AssetKit
  * @typedef {{
- *   runKit: AssetKit,
+ *   stableKit: AssetKit,
  *   tokenKit: AssetKit,
  *   vaultFactory: ERef<import('../types').VaultFactoryPublicFacet>,
  *   vaultCollateralManager: ERef<import('../types').VaultCollateralManager> | null,
@@ -35,16 +35,17 @@ async function getPurseBalance(purse) {
  * }} startParam
  */
 export default async function startAgent({
-  runKit: {
-    brand: runBrand,
-    purse: runPurse,
-    displayInfo: { decimalPlaces: runDecimalPlaces },
+  stableKit: {
+    brand: stableBrand,
+    purse: stablePurse,
+    symbol: stableSymbol,
+    displayInfo: { decimalPlaces: stableDecimalPlaces },
   },
   tokenKit: {
     brand: collateralBrand,
     purse: collateralPurse,
     displayInfo: { decimalPlaces: collateralDecimalPlaces },
-    name: collateralToken,
+    symbol: collateralSymbol,
   },
   vaultFactory,
   vaultCollateralManager,
@@ -55,14 +56,14 @@ export default async function startAgent({
   const collateralBalance = await getPurseBalance(collateralPurse);
   if (AmountMath.isEmpty(collateralBalance)) {
     throw Error(
-      `create-vault: getCurrentAmount(${collateralToken}) broken (says 0)`,
+      `create-vault: getCurrentAmount(${collateralSymbol}) broken (says 0)`,
     );
   }
   console.error(
     `create-vault: initial balance: ${disp(
       collateralBalance,
       collateralDecimalPlaces,
-    )} ${collateralToken}`,
+    )} ${collateralSymbol}`,
   );
   // put 1% into the vault
   const collateralToLock = AmountMath.make(
@@ -76,8 +77,11 @@ export default async function startAgent({
   const cdata = collaterals.find((c) => c.brand === collateralBrand);
   assert(cdata);
   const priceRate = cdata.marketPrice;
-  const half = makeRatio(BigInt(50), runBrand);
-  const wantedRun = multiplyBy(multiplyBy(collateralToLock, priceRate), half);
+  const half = makeRatio(BigInt(50), stableBrand);
+  const wantedStable = multiplyBy(
+    multiplyBy(collateralToLock, priceRate),
+    half,
+  );
 
   console.error(`create-vault: tools ready`);
 
@@ -85,7 +89,10 @@ export default async function startAgent({
     `create-vault: collateralToLock=${disp(
       collateralToLock,
       collateralDecimalPlaces,
-    )} ${collateralToken}, wantedRun=${disp(wantedRun, runDecimalPlaces)}`,
+    )} ${collateralSymbol}, wantedStable=${disp(
+      wantedStable,
+      stableDecimalPlaces,
+    )} ${stableSymbol}`,
   );
 
   // we fix the 1% 'collateralToLock' value at startup, and use it for all cycles
@@ -100,7 +107,7 @@ export default async function startAgent({
         Collateral: collateralToLock,
       },
       want: {
-        RUN: wantedRun,
+        [stableSymbol]: wantedStable,
       },
     });
     const payment = harden({
@@ -108,13 +115,13 @@ export default async function startAgent({
     });
     const seatP = E(zoe).offer(openInvitationP, proposal, payment);
     await seatP;
-    const [collateralPayout, runPayout] = await Promise.all([
+    const [collateralPayout, stablePayout] = await Promise.all([
       E(seatP).getPayout('Collateral'),
-      E(seatP).getPayout('RUN'),
+      E(seatP).getPayout(stableSymbol),
     ]);
     await Promise.all([
       E(collateralPurse).deposit(collateralPayout),
-      E(runPurse).deposit(runPayout),
+      E(stablePurse).deposit(stablePayout),
     ]);
     const offerResult = await E(seatP).getOfferResult();
     console.error(`create-vault: cycle: vault opened`);
@@ -123,27 +130,29 @@ export default async function startAgent({
 
   async function closeVault(vault) {
     console.error('create-vault: closeVault');
-    const runNeeded = await fallback(
+    const stableNeeded = await fallback(
       E(vault).getCurrentDebt(),
       E(vault).getDebtAmount(),
     );
     const closeInvitationP = E(vault).makeCloseInvitation();
     const proposal = {
       give: {
-        RUN: runNeeded,
+        [stableSymbol]: stableNeeded,
       },
       want: {
         Collateral: AmountMath.makeEmpty(collateralBrand),
       },
     };
-    const payment = harden({ RUN: E(runPurse).withdraw(runNeeded) });
+    const payment = harden({
+      [stableSymbol]: E(stablePurse).withdraw(stableNeeded),
+    });
     const seatP = E(zoe).offer(closeInvitationP, proposal, payment);
-    const [runPayout, collateralPayout] = await Promise.all([
-      E(seatP).getPayout('RUN'),
+    const [stablePayout, collateralPayout] = await Promise.all([
+      E(seatP).getPayout(stableSymbol),
       E(seatP).getPayout('Collateral'),
     ]);
     await Promise.all([
-      E(runPurse).deposit(runPayout),
+      E(stablePurse).deposit(stablePayout),
       E(collateralPurse).deposit(collateralPayout),
       E(seatP).getOfferResult(),
     ]);
@@ -154,18 +163,19 @@ export default async function startAgent({
     async doVaultCycle() {
       const vault = await openVault();
       await closeVault(vault);
-      const [newRunBalance, newCollateralBalance] = await Promise.all([
-        getPurseBalance(runPurse),
+      const [newStableBalance, newCollateralBalance] = await Promise.all([
+        getPurseBalance(stablePurse),
         getPurseBalance(collateralPurse),
       ]);
       console.error('create-vault: cycle: done');
       return {
-        newRunBalanceDisplay: disp(newRunBalance, runDecimalPlaces),
+        newStableBalanceDisplay: disp(newStableBalance, stableDecimalPlaces),
         newCollateralBalanceDisplay: disp(
           newCollateralBalance,
           collateralDecimalPlaces,
         ),
-        collateralToken,
+        stableSymbol,
+        collateralSymbol,
       };
     },
   });

--- a/loadgen/contract/agent-create-vault.js
+++ b/loadgen/contract/agent-create-vault.js
@@ -71,6 +71,8 @@ export default async function startAgent({
     collateralBalance.value / BigInt(100),
   );
 
+  const stableKeyword = stableSymbol === 'RUN' ? 'RUN' : 'Minted';
+
   // we only withdraw half the value of the collateral, giving us 200%
   // collateralization
   const collaterals = await E(vaultFactory).getCollaterals();
@@ -107,7 +109,7 @@ export default async function startAgent({
         Collateral: collateralToLock,
       },
       want: {
-        [stableSymbol]: wantedStable,
+        [stableKeyword]: wantedStable,
       },
     });
     const payment = harden({
@@ -117,7 +119,7 @@ export default async function startAgent({
     await seatP;
     const [collateralPayout, stablePayout] = await Promise.all([
       E(seatP).getPayout('Collateral'),
-      E(seatP).getPayout(stableSymbol),
+      E(seatP).getPayout(stableKeyword),
     ]);
     await Promise.all([
       E(collateralPurse).deposit(collateralPayout),
@@ -137,18 +139,18 @@ export default async function startAgent({
     const closeInvitationP = E(vault).makeCloseInvitation();
     const proposal = {
       give: {
-        [stableSymbol]: stableNeeded,
+        [stableKeyword]: stableNeeded,
       },
       want: {
         Collateral: AmountMath.makeEmpty(collateralBrand),
       },
     };
     const payment = harden({
-      [stableSymbol]: E(stablePurse).withdraw(stableNeeded),
+      [stableKeyword]: E(stablePurse).withdraw(stableNeeded),
     });
     const seatP = E(zoe).offer(closeInvitationP, proposal, payment);
     const [stablePayout, collateralPayout] = await Promise.all([
-      E(seatP).getPayout(stableSymbol),
+      E(seatP).getPayout(stableKeyword),
       E(seatP).getPayout('Collateral'),
     ]);
     await Promise.all([

--- a/loadgen/contract/agent-prepare-loadgen.js
+++ b/loadgen/contract/agent-prepare-loadgen.js
@@ -28,11 +28,29 @@ import { fallback } from './fallback.js';
  * }} startParam
  */
 
-const tokenBrandPetname = 'LGT';
+const tokenSymbolPetname = 'LGT';
 const BASIS_POINTS = 10000n;
 
 // This is loaded by the spawner into a new 'spawned' vat on the solo node.
 // The default export function is called with some args.
+
+/**
+ * @callback PurseMatcher
+ * @param {PursesFullState} state
+ * @returns {string | undefined} A symbol petname to use if found
+ */
+
+/**
+ * @param {string} symbol
+ * @returns {PurseMatcher}
+ */
+const getSymbolPetnameMatcher =
+  (symbol) =>
+  ({ brandPetname: candidateBrand, pursePetname: candidatePurse }) =>
+    candidateBrand === issuerPetnames[symbol] &&
+    candidatePurse === pursePetnames[symbol]
+      ? symbol
+      : undefined;
 
 /**
  * @param {Object} param0
@@ -50,24 +68,37 @@ const makePurseFinder = ({ wallet, walletAdmin }) => {
     /**
      * @template {boolean} [T=false]
      * @param {Object} param0
-     * @param {string} param0.brandPetname
+     * @param {string} [param0.symbolPetname]
+     * @param {PurseMatcher} [param0.purseMatcher]
      * @param {T} [param0.existingOnly]
      * @returns {Promise<{kit: Promise<import('../types.js').NatAssetKit>, balance: Amount<'nat'>} | (true extends T ? {kit: undefined, balance: undefined} : never)>}
      */
-    async find({ brandPetname, existingOnly = /** @type {T} */ (false) }) {
+    async find({
+      symbolPetname,
+      purseMatcher,
+      existingOnly = /** @type {T} */ (false),
+    }) {
+      const matcher =
+        purseMatcher ||
+        getSymbolPetnameMatcher((assert(symbolPetname), symbolPetname));
+
       /** @type {PursesFullState | undefined} */
       let foundPurseState;
+      /** @type {string | undefined} */
+      let foundPurseSymbol;
 
       /** @param {PursesFullState[]} pursesStates */
       const findPurse = (pursesStates) => {
-        foundPurseState = pursesStates.find(
-          ({ brandPetname: candidateBrand, pursePetname: candidatePurse }) =>
-            candidateBrand === issuerPetnames[brandPetname] &&
-            candidatePurse === pursePetnames[brandPetname],
-        );
+        for (const state of pursesStates) {
+          foundPurseSymbol = matcher(state);
+          if (foundPurseSymbol != null) {
+            foundPurseState = state;
+            break;
+          }
+        }
         if (foundPurseState) {
           console.error(
-            `prepare-loadgen: Found ${brandPetname} purse`,
+            `prepare-loadgen: Found ${foundPurseSymbol} purse`,
             foundPurseState,
           );
           return true;
@@ -98,15 +129,16 @@ const makePurseFinder = ({ wallet, walletAdmin }) => {
         // the above loop will not exit until it finds a purse
         assert(foundPurseState);
       }
+      assert(foundPurseSymbol);
 
-      const issuer = E(wallet).getIssuer(issuerPetnames[brandPetname]);
+      const issuer = E(wallet).getIssuer(foundPurseState.brandPetname);
 
       return {
         kit: allValues({
           issuer,
           brand: foundPurseState.brand,
           purse: foundPurseState.purse,
-          name: brandPetname,
+          symbol: foundPurseSymbol,
           displayInfo: foundPurseState.displayInfo,
         }),
         balance: AmountMath.make(
@@ -136,15 +168,15 @@ export default async function startAgent({
 
   const purseFinder = makePurseFinder({ wallet, walletAdmin });
 
-  // Get the RUN purse and initial balance from the wallet
+  // Get the stable token purse and initial balance from the wallet
   // This shouldn't require, on its own, any requests to the chain as
   // it just waits until the wallet bootstrap is sufficiently advanced
-  const { kit: runKit, balance: initialRunBalance } = E.get(
-    purseFinder.find({ brandPetname: 'RUN' }),
+  const { kit: stableKit, balance: initialStableBalance } = E.get(
+    purseFinder.find({ symbolPetname: 'RUN' }),
   );
 
-  // Setup the fee purse if necessary and get the remaining RUN balance
-  const runBalance = (async () => {
+  // Setup the fee purse if necessary and get the remaining stable token balance
+  const stableBalance = (async () => {
     const feePurse = await E(faucet)
       .getFeePurse()
       .catch((err) => {
@@ -156,26 +188,31 @@ export default async function startAgent({
       });
 
     if (!feePurse) {
-      return initialRunBalance;
+      return initialStableBalance;
     }
 
-    const run = await initialRunBalance;
-    const thirdRunAmount = AmountMath.make(run.brand, run.value / 3n);
+    const balance = await initialStableBalance;
+    const thirdBalanceAmount = AmountMath.make(
+      balance.brand,
+      balance.value / 3n,
+    );
 
-    if (AmountMath.isEmpty(run)) {
-      throw Error(`no RUN, loadgen cannot proceed`);
+    if (AmountMath.isEmpty(balance)) {
+      throw Error(`empty stable token balance, loadgen cannot proceed`);
     }
 
     console.error(
-      `prepare-loadgen: depositing ${disp(thirdRunAmount)} into the fee purse`,
+      `prepare-loadgen: depositing ${disp(
+        thirdBalanceAmount,
+      )} into the fee purse`,
     );
-    const runPurse = E.get(runKit).purse;
+    const stablePurse = E.get(stableKit).purse;
     // Purse doesn't "lock" during withdrawal so we need to
     // wait on payment before asking about balance
-    const feePayment = await E(runPurse).withdraw(thirdRunAmount);
+    const feePayment = await E(stablePurse).withdraw(thirdBalanceAmount);
 
     const remainingBalance = /** @type {Promise<Amount<'nat'>>} */ (
-      E(runPurse).getCurrentAmount()
+      E(stablePurse).getCurrentAmount()
     );
     await E(feePurse).deposit(feePayment);
 
@@ -188,7 +225,7 @@ export default async function startAgent({
    */
   const withFee = async (
     promise = /** @type {Promise<any>} */ (Promise.resolve()),
-  ) => Promise.all([promise, runBalance]).then(([value]) => value);
+  ) => Promise.all([promise, stableBalance]).then(([value]) => value);
 
   // Use Zoe to install mint for loadgen token, return kit
   // Needs fee purse to be provisioned
@@ -207,7 +244,7 @@ export default async function startAgent({
     const customTerms = {
       assetKind: AssetKind.NAT,
       displayInfo,
-      keyword: tokenBrandPetname,
+      keyword: tokenSymbolPetname,
     };
 
     const installation = E(zoe).install(mintBundle);
@@ -223,14 +260,14 @@ export default async function startAgent({
       E.get(startInstanceResult);
 
     return allValues({
-      name: tokenBrandPetname,
+      symbol: tokenSymbolPetname,
       displayInfo,
       mint,
       issuer,
       brand: E(issuer).getBrand(),
       purse: (async () => {
-        const issuerPetname = issuerPetnames[tokenBrandPetname];
-        const pursePetname = pursePetnames[tokenBrandPetname];
+        const issuerPetname = issuerPetnames[tokenSymbolPetname];
+        const pursePetname = pursePetnames[tokenSymbolPetname];
         await E(walletAdmin).addIssuer(issuerPetname, await issuer);
         await E(walletAdmin).makeEmptyPurse(issuerPetname, pursePetname);
         return E(wallet).getPurse(pursePetname);
@@ -250,8 +287,8 @@ export default async function startAgent({
 
   /** @type {(() => Promise<Amount<'nat'>>)[]} */
   const recoverFunding = [];
-  const fundingResult = E.when(runBalance, async (centralInitialBalance) => {
-    const { purse: centralPurse } = E.get(runKit);
+  const fundingResult = E.when(stableBalance, async (centralInitialBalance) => {
+    const { purse: centralPurse, symbol: stableSymbolP } = E.get(stableKit);
     const {
       mint: secondaryMint,
       issuer: secondaryIssuer,
@@ -259,13 +296,13 @@ export default async function startAgent({
       purse: secondaryPurse,
     } = E.get(tokenKit);
     const liquidityIssuer = fallback(
-      E(amm).addIssuer(secondaryIssuer, issuerPetnames[tokenBrandPetname]),
-      E(amm).addPool(secondaryIssuer, issuerPetnames[tokenBrandPetname]),
+      E(amm).addIssuer(secondaryIssuer, issuerPetnames[tokenSymbolPetname]),
+      E(amm).addPool(secondaryIssuer, issuerPetnames[tokenSymbolPetname]),
     );
     const liquidityBrandP = E(liquidityIssuer).getBrand();
 
     if (AmountMath.isEmpty(centralInitialBalance)) {
-      throw Error(`no RUN, loadgen cannot proceed`);
+      throw Error(`no stable token balance, loadgen cannot proceed`);
     }
 
     /** @type {Amount<'nat'>} */
@@ -282,7 +319,10 @@ export default async function startAgent({
     // The faucet task taps 100_000n of the loadgen token
     // We want the faucet to represent a fraction (1% ?) of the traded amounts
     // The computed amount will be used for both amm liquidity and initial purse funds
-    const secondaryBrand = await secondaryBrandP;
+    const [secondaryBrand, stableSymbol] = await Promise.all([
+      secondaryBrandP,
+      stableSymbolP,
+    ]);
     /** @type {Amount<'nat'>} */
     const secondaryAmount = AmountMath.make(
       secondaryBrand,
@@ -302,7 +342,7 @@ export default async function startAgent({
     console.error(
       `prepare-loadgen: Adding AMM liquidity: ${disp(
         centralAmount,
-      )} RUN and ${disp(secondaryAmount)} ${tokenBrandPetname}`,
+      )} ${stableSymbol} and ${disp(secondaryAmount)} ${tokenSymbolPetname}`,
     );
 
     const liquidityBrand = await liquidityBrandP;
@@ -372,7 +412,7 @@ export default async function startAgent({
 
       const { brand: collateralBrand, issuer: collateralIssuer } =
         await tokenKit;
-      const { brand: centralBrand } = await runKit;
+      const { brand: centralBrand } = await stableKit;
 
       const { toCentral, fromCentral } = E.get(
         E(amm).getPriceAuthorities(collateralBrand),
@@ -401,7 +441,7 @@ export default async function startAgent({
 
       return E(vaultFactory).addVaultType(
         collateralIssuer,
-        issuerPetnames[tokenBrandPetname],
+        issuerPetnames[tokenSymbolPetname],
         rates,
       );
     },
@@ -410,7 +450,7 @@ export default async function startAgent({
   return E.when(
     Promise.all([vaultManager, vaultFactoryPublicFacet]),
     async ([vaultManagerPresence, vaultFactory]) => {
-      const collateralTokenPetname =
+      const collateralSymbolPetname =
         fallbackCollateralToken || fallbackTradeToken;
 
       /** @type {ERef<import('../types.js').VaultCollateralManager | null>} */
@@ -426,14 +466,14 @@ export default async function startAgent({
           ammTokenKit: tokenKit,
           vaultCollateralManager,
         };
-      } else if (collateralTokenPetname) {
+      } else if (collateralSymbolPetname) {
         // Make sure the finder knows about all purses by finding the
         // LGT purse we created
-        await purseFinder.find({ brandPetname: tokenBrandPetname });
+        await purseFinder.find({ symbolPetname: tokenSymbolPetname });
 
         const { kit: vaultTokenKit } = E.get(
           purseFinder.find({
-            brandPetname: collateralTokenPetname,
+            symbolPetname: collateralSymbolPetname,
             existingOnly: true,
           }),
         );
@@ -442,12 +482,12 @@ export default async function startAgent({
         let ammTokenKit = vaultTokenKit.then((value) => value || tokenKit);
         if (
           (fallbackTradeToken &&
-            fallbackTradeToken !== collateralTokenPetname) ||
+            fallbackTradeToken !== collateralSymbolPetname) ||
           !(await fundingResult)
         ) {
           ({ kit: ammTokenKit } = E.get(
             purseFinder.find({
-              brandPetname: /** @type {string} */ (fallbackTradeToken),
+              symbolPetname: /** @type {string} */ (fallbackTradeToken),
               existingOnly: true,
             }),
           ));
@@ -466,7 +506,7 @@ export default async function startAgent({
     harden(
       await allValues({
         tokenKit,
-        runKit,
+        stableKit,
         amm,
         ammTokenKit,
         vaultManager,

--- a/loadgen/contract/agent-tap-faucet.js
+++ b/loadgen/contract/agent-tap-faucet.js
@@ -33,7 +33,7 @@ export default async function startAgent({ tokenKit }) {
       const amount = await E(tokenKit.purse).getCurrentAmount();
       return {
         amountDisplay: disp(amount, tokenKit.displayInfo.decimalPlaces),
-        faucetToken: tokenKit.name,
+        faucetToken: tokenKit.symbol,
       };
     },
   });

--- a/loadgen/contract/fallback.js
+++ b/loadgen/contract/fallback.js
@@ -1,5 +1,10 @@
 // @ts-check
 
+/**
+ * @template T
+ * @param {Promise<T>[]} args
+ * @returns {Promise<T>}
+ */
 export const fallback = (...args) =>
   Promise.allSettled(args).then((results) => {
     for (const result of results) {

--- a/loadgen/task-create-vault.js
+++ b/loadgen/task-create-vault.js
@@ -7,10 +7,10 @@ import { getLoadgenKit } from './prepare-loadgen.js';
 
 // Prepare to create and close a vault on each cycle. We measure our
 // available collateral token at startup. On each cycle, we deposit 1% of that value as
-// collateral to borrow as much RUN as they'll give us. Then we pay back the
-// loan (using all the borrowed RUN, plus some more as a fee), getting back
+// collateral to borrow as much IST/RUN as they'll give us. Then we pay back the
+// loan (using all the borrowed IST/RUN, plus some more as a fee), getting back
 // most (but not all?) of our collateral. If we are not interrupted, we finish each
-// cycle with slightly less collateral and RUN than we started (because of fees),
+// cycle with slightly less collateral and IST/RUN than we started (because of fees),
 // but with no vaults or loans outstanding.
 
 /**
@@ -34,16 +34,16 @@ export async function prepareVaultCycle(home, deployPowers) {
     // create the solo-side agent to drive each cycle, let it handle zoe
     const installerP = E(spawner).install(agentBundle);
     const {
-      runKit,
+      stableKit,
       vaultTokenKit: tokenKit,
       vaultFactory,
       vaultCollateralManager,
     } = await loadgenKit;
-    if (runKit && tokenKit && vaultFactory) {
+    if (stableKit && tokenKit && vaultFactory) {
       /** @type {import('./contract/agent-create-vault').startParam} */
       const startParam = {
         tokenKit,
-        runKit,
+        stableKit,
         vaultFactory,
         vaultCollateralManager,
         zoe,
@@ -63,12 +63,13 @@ export async function prepareVaultCycle(home, deployPowers) {
       throw new Error('No agent available');
     }
     const {
-      newRunBalanceDisplay,
+      newStableBalanceDisplay,
       newCollateralBalanceDisplay,
-      collateralToken,
+      stableSymbol,
+      collateralSymbol,
     } = await E(agent).doVaultCycle();
     console.log(
-      `create-vault: new purse balances: RUN=${newRunBalanceDisplay} ${collateralToken}=${newCollateralBalanceDisplay}`,
+      `create-vault: new purse balances: ${stableSymbol}=${newStableBalanceDisplay} ${collateralSymbol}=${newCollateralBalanceDisplay}`,
     );
   }
 

--- a/loadgen/task-trade-amm.js
+++ b/loadgen/task-trade-amm.js
@@ -26,10 +26,10 @@ export async function prepareAMMTrade(home, deployPowers) {
 
     // create the solo-side agent to drive each cycle, let it handle zoe
     const installerP = E(spawner).install(agentBundle);
-    const { runKit, ammTokenKit: tokenKit, amm } = await loadgenKit;
-    if (runKit && tokenKit && amm) {
+    const { stableKit, ammTokenKit: tokenKit, amm } = await loadgenKit;
+    if (stableKit && tokenKit && amm) {
       /** @type {import('./contract/agent-trade-amm').startParam} */
-      const startParam = { tokenKit, runKit, amm, zoe };
+      const startParam = { tokenKit, stableKit, amm, zoe };
       agent = await E(installerP).spawn(startParam);
       await E(scratch).set(key, agent);
       console.log(`trade-amm: prepare: agent installed`);
@@ -44,10 +44,14 @@ export async function prepareAMMTrade(home, deployPowers) {
     if (!agent) {
       throw new Error('No agent available');
     }
-    const { newRunBalanceDisplay, newTargetBalanceDisplay, targetToken } =
-      await E(agent).doAMMCycle();
+    const {
+      newStableBalanceDisplay,
+      newTargetBalanceDisplay,
+      stableSymbol,
+      targetSymbol,
+    } = await E(agent).doAMMCycle();
     console.log(
-      `trade-amm: new purse balances: RUN=${newRunBalanceDisplay} ${targetToken}=${newTargetBalanceDisplay}`,
+      `trade-amm: new purse balances: ${stableSymbol}=${newStableBalanceDisplay} ${targetSymbol}=${newTargetBalanceDisplay}`,
     );
   }
   console.log(`trade-amm: prepare: ready for cycles`);

--- a/loadgen/types.js
+++ b/loadgen/types.js
@@ -38,7 +38,7 @@ export {};
 /**
  * @template {AssetKind} [K=AssetKind]
  * @typedef {Object} AssetKit
- * @property {string} name
+ * @property {string} symbol
  * @property {Mint<K>} [mint]
  * @property {Issuer<K>} issuer
  * @property {Brand<K>} brand


### PR DESCRIPTION
https://github.com/Agoric/agoric-sdk/issues/5326 is renaming RUN -> IST. This PR refactors the loadgen to no longer hardcode `RUN`, and instead names anything related with "stable". Then it adds a dynamic fallback from IST to RUN for backwards compatibility.

Successfully tested locally the "local-chain" variant against the same revisions as https://github.com/Agoric/testnet-load-generator/pull/71, as well as the current master of agoric-sdk: `12e61941`. The "testnet" variant against the same agoric-sdk master revision is also passing, allowing a safe merge without breaking agoric-sdk's CI.

Tested against the [IST rename branch](https://github.com/Agoric/agoric-sdk/pull/5585) (`4800-unRUN`).