### PR TITLE
fix(loadgen): Bump vault debt limit

### DIFF
--- a/loadgen/contract/agent-prepare-loadgen.js
+++ b/loadgen/contract/agent-prepare-loadgen.js
@@ -391,7 +391,7 @@ export default async function startAgent({
       ]);
 
       const rates = {
-        debtLimit: AmountMath.make(centralBrand, 1_000_000_000n),
+        debtLimit: AmountMath.make(centralBrand, 100_000_000_000n),
         liquidationMargin: makeRatio(105n, centralBrand),
         liquidationPenalty: makeRatio(10n, centralBrand, 100n, centralBrand),
         interestRate: makeRatio(250n, centralBrand, BASIS_POINTS),


### PR DESCRIPTION
The daily-perf loadgen is trading significantly enough to sporadically hit the debt limit