### PR TITLE
feat(runner): handle missing procfs

### DIFF
--- a/runner/lib/helpers/procsfs.js
+++ b/runner/lib/helpers/procsfs.js
@@ -49,6 +49,7 @@ export const makeProcfsHelper = ({ fs, spawn, startPid = process.pid }) => {
 
     return parseInt(res.toString(bufferOptions.encoding), 10);
   })();
+  userHertzP.catch(() => {});
 
   /** @typedef {string[]} ProcStat */
   /**
@@ -106,6 +107,7 @@ export const makeProcfsHelper = ({ fs, spawn, startPid = process.pid }) => {
   const getStartTicks = (stat) => parseInt(stat[21], 10);
 
   const startTicksOriginP = getStat(startPid).then(getStartTicks);
+  startTicksOriginP.catch(() => {});
 
   // TODO: Use a WeakValueMap
   /** @type {Map<string, ProcessInfo>} */

--- a/runner/lib/monitor/loadgen-monitor.js
+++ b/runner/lib/monitor/loadgen-monitor.js
@@ -1,12 +1,16 @@
 /** @typedef {import('../stats/types.js').StageStats} StageStats */
 
 /**
+ * @typedef {object} TaskNotifier
+ * @property {(task: string, seq: number) => void} start
+ * @property {(task: string, seq: number, success: boolean) => void} finish
+ */
+
+/**
  * @param {import("../tasks/types.js").RunLoadgenInfo} loadgenInfo
  * @param {object} param1
  * @param {StageStats} param1.stats
- * @param {object} [param1.notifier]
- * @param {(task: string, seq: number) => void} [param1.notifier.start]
- * @param {(task: string, seq: number, success: boolean) => void} [param1.notifier.finish]
+ * @param {TaskNotifier} [param1.notifier]
  * @param {Console} param1.console
  */
 export const monitorLoadgen = async (

--- a/runner/lib/tasks/local-chain.js
+++ b/runner/lib/tasks/local-chain.js
@@ -334,7 +334,7 @@ export const makeTasks = ({
 
         const processInfo = await getProcessInfo(
           /** @type {number} */ (chainCp.pid),
-        );
+        ).catch(() => undefined);
 
         return harden({
           stop,
@@ -576,7 +576,7 @@ export const makeTasks = ({
 
         const processInfo = await getProcessInfo(
           /** @type {number} */ (soloCp.pid),
-        );
+        ).catch(() => undefined);
 
         const stop = () => {
           ignoreKill.signal = 'SIGTERM';

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -157,15 +157,17 @@ export const makeTasks = ({
     }
 
     console.log('Fetching network config');
-    // eslint-disable-next-line jsdoc/check-alignment
-    const { chainName, peers, rpcAddrs, seeds } = /**
-     * @type {{
-     *   chainName: string,
-     *   peers: string[],
-     *   rpcAddrs: string[],
-     *   seeds: string[]
-     * } & Record<string, unknown>}
-     */ (await fetchAsJSON(`${testnetOrigin}/network-config`));
+    /**
+     * @typedef {object} NetworkConfigRequired
+     * @property {string} chainName
+     * @property {string[]} peers
+     * @property {string[]} rpcAddrs
+     * @property {string[]} seeds
+     */
+    const { chainName, peers, rpcAddrs, seeds } =
+      /** @type {NetworkConfigRequired & Record<string, unknown>} */ (
+        await fetchAsJSON(`${testnetOrigin}/network-config`)
+      );
 
     if (withMonitor !== false) {
       storageLocations.chainStorageLocation = chainStateDir;
@@ -208,7 +210,9 @@ export const makeTasks = ({
         const config = await TOML.parse.async(
           await fs.readFile(configPath, 'utf-8'),
         );
-        const configP2p = /** @type {TOML.JsonMap} */ (config.p2p);
+        const configP2p = /** @type {import('@iarna/toml').JsonMap} */ (
+          config.p2p
+        );
         configP2p.persistent_peers = peers.join(',');
         configP2p.seeds = seeds.join(',');
         configP2p.addr_book_strict = false;

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -496,7 +496,7 @@ ${chainName} chain does not yet know of address ${soloAddr}
 
         const processInfo = await getProcessInfo(
           /** @type {number} */ (chainCp.pid),
-        );
+        ).catch(() => undefined);
 
         return harden({
           stop,
@@ -607,7 +607,7 @@ ${chainName} chain does not yet know of address ${soloAddr}
 
         const processInfo = await getProcessInfo(
           /** @type {number} */ (soloCp.pid),
-        );
+        ).catch(() => undefined);
 
         const stop = () => {
           ignoreKill.signal = 'SIGTERM';

--- a/runner/lib/tasks/types.d.ts
+++ b/runner/lib/tasks/types.d.ts
@@ -25,7 +25,9 @@ export type TaskResult = {
 
 export type RunKernelInfo = {
   readonly slogLines: AsyncIterable<Buffer>;
-  readonly processInfo: import('../helpers/process-info.js').ProcessInfo;
+  readonly processInfo:
+    | import('../helpers/process-info.js').ProcessInfo
+    | undefined;
 };
 
 export type TaskEventStatus = Record<string, unknown> & {


### PR DESCRIPTION
Refs #41 

Attempt at supporting MacOS in the loadgen. Removes the hard `procfs` dependency at the cost of disabling the process monitor logic, and some fallback mechanisms when not present.

Unfortunately it looks like a full loadgen still fails, some issue with the solo stalling, possibly related to the slog file. Since the issue may be unrelated to the loadgen, landing these changes.

Drive-by type/lint fixes
