### PR TITLE
fix(runner): handle empty blocks with nest slog lines

### DIFF
--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -548,8 +548,12 @@ const main = async (progName, rawArgs, powers) => {
           }
 
           if (resolveFirstEmptyBlock) {
-            if (block.slogLines === 0 || emptyBlockRetries === 0) {
-              if (block.slogLines === 0) {
+            if (
+              block.slogLines === 0 ||
+              block.computrons === 0 ||
+              emptyBlockRetries === 0
+            ) {
+              if (block.slogLines === 0 || block.computrons === 0) {
                 logPerfEvent('stage-first-empty-block', {
                   block: block.blockHeight,
                 });

--- a/runner/lib/monitor/slog-monitor.js
+++ b/runner/lib/monitor/slog-monitor.js
@@ -291,6 +291,8 @@ export const monitorSlog = async (
             blockHeight,
             'linesInBlock=',
             block.slogLines,
+            'computrons=',
+            block.computrons,
           );
           block = null;
         }


### PR DESCRIPTION
[Rework of cosmic-swingset to change action processing](https://github.com/Agoric/agoric-sdk/issues/6210) will always nest `cosmic-swingset-run-start` and `cosmic-swingset-run-finish` slog events in the `end-block`, so look at `computrons` to decide if the block was actually empty, which really should have been the case a long time ago.