### PR TITLE
fix(runner): handle replay after init

### DIFF
--- a/runner/lib/monitor/slog-monitor.js
+++ b/runner/lib/monitor/slog-monitor.js
@@ -59,9 +59,10 @@ import { warnOnRejection } from '../helpers/async.js';
  *   time: TimeValueS,
  *   monotime?: number,
  *   type: 'deliver',
- *   crankNum: number,
+ *   crankNum?: number,
  *   vatID: string,
  *   deliveryNum: number,
+ *   replay: boolean,
  * }} SlogCosmicSwingsetVatDeliveryEvent
  */
 
@@ -70,9 +71,10 @@ import { warnOnRejection } from '../helpers/async.js';
  *   time: TimeValueS,
  *   monotime?: number,
  *   type: 'deliver-result',
- *   crankNum: number,
+ *   crankNum?: number,
  *   vatID: string,
  *   deliveryNum: number,
+ *   replay: boolean,
  *   dr: [
  *    tag: 'ok' | 'error',
  *    message: null | string,
@@ -308,12 +310,15 @@ export const monitorSlog = async (
             crankNum,
             deliveryNum,
             vatID,
+            replay,
             dr: [, , usage],
           } = event;
-          if (usage && typeof usage === 'object' && 'compute' in usage) {
-            computrons = usage.compute;
+          if (!replay && crankNum !== undefined) {
+            if (usage && typeof usage === 'object' && 'compute' in usage) {
+              computrons = usage.compute;
+            }
+            block.recordDelivery({ crankNum, deliveryNum, vatID, computrons });
           }
-          block.recordDelivery({ crankNum, deliveryNum, vatID, computrons });
         }
         break;
       }


### PR DESCRIPTION
With https://github.com/Agoric/agoric-sdk/pull/6442 we're only preloading at init the first 25 vats, and then dynamically loading any vat on first delivery.

As detailed in https://github.com/Agoric/agoric-sdk/pull/6520/, we observed an integration test failing on stage 2 (restart with no load). I tracked it to replay deliveries, which miss a `crankNum` and happen during a block (aka after init).

With this PR, we now handle replay deliveries in the loadgen runner slog monitor.