### PR TITLE
fix: handle missing AMM

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -74,6 +74,5 @@ jobs:
           SDK_SRC: ${{ github.workspace }}/agoric-sdk
         run: |
           ./start.sh --no-stage.save-storage --no-reset \
-            --stage.loadgen.vault.interval=12 --stage.loadgen.vault.limit=2 \
-            --stage.loadgen.amm.interval=12 --stage.loadgen.amm.wait=6 --stage.loadgen.amm.limit=2 \
+            --stage.loadgen.faucet.interval=6 --stage.loadgen.faucet.limit=4 \
             --stages=3 --stage.duration=10 --stage.loadgen.cycles=4

--- a/loadgen/contract/agent-prepare-loadgen.js
+++ b/loadgen/contract/agent-prepare-loadgen.js
@@ -526,7 +526,7 @@ export default async function startAgent({
       await allValues({
         tokenKit,
         stableKit,
-        amm,
+        amm: Promise.resolve(amm).catch(() => null),
         ammTokenKit,
         vaultManager,
         vaultFactory: vaultFactoryPublicFacet,


### PR DESCRIPTION
Apparently all the fallback logic was there to handle a missing AMM, with just one tiny mistake.

This does not (yet) attempt to setup the vault without AMM.

`agoric-sdk` will also need to be updated to not try to run the amm & vault tasks (as that will fail without the agents being installed) but similarly run only the faucet task for now.

#agoric-sdk-branch: 7055-exciseAMM