### PR TITLE
feat(runner): Enable starting testnet follower from state-sync

### DIFF
--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -279,6 +279,9 @@ const main = async (progName, rawArgs, powers) => {
   /** @type {string} */
   let testnetOrigin;
 
+  /** @type {boolean | undefined} */
+  let useStateSync;
+
   const profile = argv.profile == null ? 'local' : argv.profile;
 
   switch (profile) {
@@ -291,6 +294,7 @@ const main = async (progName, rawArgs, powers) => {
     case 'stage':
       makeTasks = makeTestnetTasks;
       testnetOrigin = argv.testnetOrigin || `https://${profile}.agoric.net`;
+      useStateSync = argv.useStateSync;
       break;
     default:
       throw new Error(`Unexpected profile option: ${profile}`);
@@ -382,6 +386,7 @@ const main = async (progName, rawArgs, powers) => {
     metadata: {
       profile,
       testnetOrigin,
+      useStateSync,
       ...envInfo,
       testData: argv.testData,
     },
@@ -961,6 +966,7 @@ const main = async (progName, rawArgs, powers) => {
           chainOnly: globalChainOnly,
           withMonitor,
           testnetOrigin,
+          useStateSync,
         };
         logPerfEvent('setup-tasks-start', setupConfig);
         ({ chainStorageLocation, clientStorageLocation } =

--- a/runner/lib/stats/types.d.ts
+++ b/runner/lib/stats/types.d.ts
@@ -161,6 +161,7 @@ export interface StageStats extends StageStatsInitData {
 export interface RunMetadata {
   readonly profile: string;
   readonly testnetOrigin?: string;
+  readonly useStateSync?: boolean | undefined;
   readonly agChainCosmosVersion?: unknown;
   readonly testData?: unknown;
 }

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -235,6 +235,13 @@ export const makeTasks = ({
           const currentBlockInfo = await fetchAsJSON(
             `http://${rpcAddrs[0]}/block`,
           );
+
+          // `trustHeight` is the block height considered as the "root of trust"
+          // for state-sync. The node will attempt to find a snapshot offered for
+          // a block at or after this height, and will validate that block's hash
+          // using a light client with the configured RPC servers.
+          // We want to use a block height recent enough, but for which a snapshot
+          // exists since then.
           const stateSyncInterval =
             Number(process.env.AG_SETUP_COSMOS_STATE_SYNC_INTERVAL) || 2000;
           const trustHeight = Math.max(

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -182,20 +182,12 @@ export const makeTasks = ({
       const genesisPath = joinPath(chainStateDir, 'config', 'genesis.json');
 
       if (!(await fsExists(genesisPath))) {
-        console.log('Fetching genesis');
-        const genesis = await fetchAsJSON(`${testnetOrigin}/genesis.json`);
-
         await childProcessDone(
           printerSpawn(
             sdkBinaries.cosmosChain,
             ['init', '--chain-id', chainName, `loadgen-monitor-${Date.now()}`],
             { stdio },
           ),
-        );
-
-        fs.writeFile(
-          joinPath(chainStateDir, 'config', 'genesis.json'),
-          JSON.stringify(genesis),
         );
 
         await childProcessDone(
@@ -228,6 +220,14 @@ export const makeTasks = ({
         configP2p.addr_book_strict = false;
         delete config.log_level;
         await fs.writeFile(configPath, TOML.stringify(config));
+
+        console.log('Fetching genesis');
+        const genesis = await fetchAsJSON(`${testnetOrigin}/genesis.json`);
+
+        fs.writeFile(
+          joinPath(chainStateDir, 'config', 'genesis.json'),
+          JSON.stringify(genesis),
+        );
       }
 
       if (loadgenBootstrapConfig) {


### PR DESCRIPTION
This change adds an option in preparation of https://github.com/Agoric/agoric-sdk/issues/3769 to allow the testnet runner to join using a state-sync snapshot instead of catching up from genesis. This will be exercised in the CI deployment integration test once https://github.com/Agoric/agoric-sdk/compare/mhofman/5542-export-state-sync gets merged.

I have locally verified that these changes together are sufficient for that test to use state-sync (using agoric-sdk's `run-deployment-integration.sh` script)