### PR TITLE
feat(runner): support instagoric devnet

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,22 +7,22 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-18.04 # trusty
+    runs-on: ubuntu-22.04 # jammy (LTS)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: testnet-load-generator
 
       - name: Get the appropriate agoric-sdk branch
         id: get-sdk-branch
-        uses: actions/github-script@0.9.0
+        uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
             let branch = 'master';
             if (context.payload.pull_request) {
               const { body } = context.payload.pull_request;
-              const regex = /.*\#agoric-sdk-branch:\s+(\S+)/;
+              const regex = /^\#loadgen-branch:\s+(\S+)/m;
               const result = regex.exec(body);
               if (result) {
                 branch = result[1];
@@ -32,7 +32,7 @@ jobs:
             return branch;
 
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: Agoric/agoric-sdk
           submodules: 'true'
@@ -42,25 +42,25 @@ jobs:
       - name: set GOPATH
         run: echo GOPATH="$HOME/go" >> $GITHUB_ENV
         shell: bash
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - name: cache Go modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: go-cache
         with:
           path: ${{ env.GOPATH }}/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-${{ runner.arch }}-go-
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
Tweak the "testnet" mode of the loadgen to connect to an instagoric created devnet which only exposes a `network-config` but not a `genesis.json`.

Locally verified that integration tests in `agoric-sdk` still run.