### PR TITLE
fix(runner): cleaner chain shutdown and disable process monitor

### DIFF
--- a/runner/lib/main.js
+++ b/runner/lib/main.js
@@ -573,6 +573,7 @@ const main = async (progName, rawArgs, powers) => {
       };
 
       const chainMonitor =
+        /** @type {undefined | true} */ (undefined) &&
         runChainResult.processInfo &&
         makeChainMonitor(
           {

--- a/runner/lib/tasks/local-chain.js
+++ b/runner/lib/tasks/local-chain.js
@@ -281,7 +281,7 @@ export const makeTasks = ({
     );
 
     let stopped = false;
-    /** @type {{signal: undefined | 'SIGTERM'}} */
+    /** @type {{signal: undefined | 'SIGTERM' | 'SIGINT'}} */
     const ignoreKill = {
       signal: undefined,
     };
@@ -294,7 +294,7 @@ export const makeTasks = ({
     const stop = () => {
       if (!stopped) {
         stopped = true;
-        ignoreKill.signal = 'SIGTERM';
+        ignoreKill.signal = 'SIGINT';
         chainCp.kill(ignoreKill.signal);
       }
     };

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -472,7 +472,7 @@ ${chainName} chain does not yet know of address ${soloAddr}
     );
 
     let stopped = false;
-    /** @type {{signal: undefined | 'SIGTERM'}} */
+    /** @type {{signal: undefined | 'SIGTERM' | 'SIGINT'}} */
     const ignoreKill = {
       signal: undefined,
     };
@@ -485,7 +485,7 @@ ${chainName} chain does not yet know of address ${soloAddr}
     const stop = () => {
       if (!stopped) {
         stopped = true;
-        ignoreKill.signal = 'SIGTERM';
+        ignoreKill.signal = 'SIGINT';
         chainCp.kill(ignoreKill.signal);
       }
     };


### PR DESCRIPTION
This updates the loadgen in the following ways:
- Use SIGINT to stop the chain process, which allows it to cleanly shutdown without errors. See https://github.com/Agoric/agoric-sdk/pull/7559
- Disables the process monitor as it's currently incompatible with multiple process per vat, which happens transiently when a worker is forced reloaded from snapshot. See https://github.com/Agoric/agoric-sdk/issues/6943