### PR TITLE
feat(runner): handle trusted block info in network config

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-22.04 # jammy (LTS)
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: testnet-load-generator
 
@@ -32,7 +32,7 @@ jobs:
             return branch;
 
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Agoric/agoric-sdk
           submodules: 'true'
@@ -46,7 +46,7 @@ jobs:
         with:
           go-version: '1.22'
       - name: cache Go modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: go-cache
         with:
           path: ${{ env.GOPATH }}/pkg/mod
@@ -58,13 +58,13 @@ jobs:
       - run: corepack enable
         shell: bash
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.18
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: [18.18]
     steps:
       - name: Checkout dapp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: 'testnet-load-generator'
 
@@ -42,7 +42,7 @@ jobs:
             return branch;
 
       - name: Checkout agoric-sdk
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: Agoric/agoric-sdk
           submodules: 'true'
@@ -52,13 +52,13 @@ jobs:
       - run: corepack enable
         shell: bash
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -94,20 +94,20 @@ jobs:
         node-version: [18.18]
     steps:
       - name: Checkout runner
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: 'testnet-load-generator'
       # Before setup-node because that action runs `yarn cache dir`. See https://github.com/actions/setup-node/issues/480#issuecomment-1915448139
       - run: corepack enable
         shell: bash
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/runner/lib/tasks/testnet.js
+++ b/runner/lib/tasks/testnet.js
@@ -188,8 +188,9 @@ export const makeTasks = ({
      * @property {string[]} rpcAddrs
      * @property {string[]} seeds
      * @property {string} gci
+     * @property {{height: string, hash: string}} [trustedBlockInfo]
      */
-    const { chainName, peers, rpcAddrs, seeds, gci } =
+    const { chainName, peers, rpcAddrs, seeds, gci, trustedBlockInfo } =
       /** @type {NetworkConfigRequired & Record<string, unknown>} */ (
         await fetchAsJSON(`${testnetOrigin}/network-config`)
       );
@@ -252,33 +253,6 @@ export const makeTasks = ({
           );
         } else {
           console.log('Fetching state-sync info');
-          /** @type {any} */
-          const currentBlockInfo = await fetchAsJSON(
-            `${rpcAddrWithScheme(rpcAddrs[0], { forceScheme: true })}/block`,
-          );
-
-          // `trustHeight` is the block height considered as the "root of trust"
-          // for state-sync. The node will attempt to find a snapshot offered for
-          // a block at or after this height, and will validate that block's hash
-          // using a light client with the configured RPC servers.
-          // We want to use a block height recent enough, but for which a snapshot
-          // exists since then.
-          const stateSyncInterval =
-            Number(process.env.AG_SETUP_COSMOS_STATE_SYNC_INTERVAL) || 2000;
-          const trustHeight = Math.max(
-            1,
-            Number(currentBlockInfo.result.block.header.height) -
-              stateSyncInterval,
-          );
-
-          /** @type {any} */
-          const trustedBlockInfo = await fetchAsJSON(
-            `${rpcAddrWithScheme(rpcAddrs[0], {
-              forceScheme: true,
-            })}/block?height=${trustHeight}`,
-          );
-          const trustHash = trustedBlockInfo.result.block_id.hash;
-
           const stateSyncRpc =
             rpcAddrs.length < 2 ? [rpcAddrs[0], rpcAddrs[0]] : rpcAddrs;
 
@@ -286,9 +260,44 @@ export const makeTasks = ({
           config.statesync.rpc_servers = stateSyncRpc
             .map((rpcAddr) => rpcAddrWithScheme(rpcAddr))
             .join(',');
-          config.statesync.trust_height = trustHeight;
-          config.statesync.trust_hash = trustHash;
+
           config.statesync.trust_period = '17280h0m0s'; // 2 years
+
+          if (trustedBlockInfo) {
+            config.statesync.trust_height = Number(trustedBlockInfo.height);
+            config.statesync.trust_hash = trustedBlockInfo.hash;
+          } else {
+            /** @type {any} */
+            const currentBlockInfo = await fetchAsJSON(
+              `${rpcAddrWithScheme(rpcAddrs[0], { forceScheme: true })}/block`,
+            );
+
+            // `trustHeight` is the block height considered as the "root of trust"
+            // for state-sync. The node will attempt to find a snapshot offered for
+            // a block at or after this height, and will validate that block's hash
+            // using a light client with the configured RPC servers.
+            // We want to use a block height recent enough, but for which a snapshot
+            // exists since then.
+            const stateSyncInterval =
+              Number(process.env.AG_SETUP_COSMOS_STATE_SYNC_INTERVAL) || 2000;
+            const trustHeight = Math.max(
+              1,
+              Number(currentBlockInfo.result.block.header.height) -
+                stateSyncInterval,
+            );
+
+            /** @type {any} */
+            const trustedBlock = await fetchAsJSON(
+              `${rpcAddrWithScheme(rpcAddrs[0], {
+                forceScheme: true,
+              })}/block?height=${trustHeight}`,
+            );
+            const trustHash = trustedBlock.result.block_id.hash;
+
+            config.statesync.trust_height = trustHeight;
+            config.statesync.trust_hash = trustHash;
+          }
+          console.log('state-sync config', config.statesync);
         }
 
         await fs.writeFile(configPath, TOML.stringify(config));


### PR DESCRIPTION
Accept trusted block info from the network-config so that an integration test can provide a recent known block info. This could be useful in case the old block picked by default may have gotten pruned.

See https://github.com/Agoric/agoric-sdk/pull/11249